### PR TITLE
Fixed Markdown resizer in Firefox 4.+

### DIFF
--- a/MarkdownDeepJS/MarkdownDeepEditorUI.js
+++ b/MarkdownDeepJS/MarkdownDeepEditorUI.js
@@ -78,8 +78,9 @@ var MarkdownDeepEditorUI=new function(){
     this.onResizerMouseDown=function(e)
     {
         // Initialize state
-        var textarea=$(e.srcElement).prevAll("textarea")[0];
-		var iOriginalMouse = e.clientY;
+	var srcElement = (window.event) ? e.srcElement : e.target;
+        var textarea=$(srcElement).prevAll("textarea")[0];
+        var iOriginalMouse = e.clientY;
         var iOriginalHeight = $(textarea).height();
             
         // Bind to required events


### PR DESCRIPTION
Fixed firefox bug with e.srcElement being null. 

Firefox 4.+ seems to populate e.target rather than e.srcElement.
