### PR TITLE
Implemented an option to enable Github-Falboured-Markup style linebreaks - i.e. no double space required

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ Debug
 *.minime-options
 *.zip
 *.nupkg
+
+_ReSharper.*

--- a/MarkdownDeep/MardownDeep.cs
+++ b/MarkdownDeep/MardownDeep.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace MarkdownDeep
 {
@@ -67,6 +68,11 @@ namespace MarkdownDeep
 		// Transform a string
 		public string Transform(string str, out Dictionary<string, LinkDefinition> definitions)
 		{
+            if (EasyLineBreaks)
+            {
+                str = Regex.Replace(str, @"^([\w\*\>\<\[][^\r\n]*)(?=\r?\n[\w\*\>\<\[].*$)", "$1  ", RegexOptions.Multiline);
+            }
+
 			// Build blocks
 			var blocks = ProcessBlocks(str);
 
@@ -201,6 +207,10 @@ namespace MarkdownDeep
 			// Done
 			return sb.ToString();
 		}
+
+        ///<summary>Set to true to automatically have line breaks entered by the user converted into br tags without 
+        /// needing double spaces</summary>  
+        public bool EasyLineBreaks { get; set; }
 
 		public int SummaryLength
 		{

--- a/MarkdownDeepJS/MarkdownDeep.js
+++ b/MarkdownDeepJS/MarkdownDeep.js
@@ -58,7 +58,8 @@ var MarkdownDeep = new function () {
         FormatCodeBlockAttributes: null,
         FormatCodeBlock: null,
         ExtractHeadBlocks: false,
-        HeadBlockContent: ""
+        HeadBlockContent: "",
+        EasyLineBreaks: false
     };
 
     var p = Markdown.prototype;
@@ -122,6 +123,12 @@ var MarkdownDeep = new function () {
 
     // Main entry point    
     Markdown.prototype.Transform = function (input) {
+
+        // Don't require double space at line end to create line break
+        if (this.EasyLineBreaks) {
+            input = input.replace(/^([\w\*\>\<\[][^\r\n]*)(?=\r?\n[\w\*\>\<\[].*$)/gm, "$1  ");
+        }
+        
         // Normalize line ends
         var rpos = input.indexOf("\r");
         if (rpos >= 0) {

--- a/MarkdownDeepJS/MarkdownDeep.min.js
+++ b/MarkdownDeepJS/MarkdownDeep.min.js
@@ -6,15 +6,16 @@ if(b[c]===e)return c;return-1}function i(){this.bz=new E(this);this.bC=[];this.b
 SafeMode:false,ExtraMode:false,MarkdownInHtml:false,AutoHeadingIDs:false,UrlBaseLocation:null,UrlRootLocation:null,
 NewWindowForExternalLinks:false,NewWindowForLocalLinks:false,NoFollowLinks:false,HtmlClassFootnotes:"footnotes",
 HtmlClassTitledImages:null,RenderingTitledImage:false,FormatCodeBlockAttributes:null,FormatCodeBlock:null,
-ExtractHeadBlocks:false,HeadBlockContent:""};var a=i.prototype;function ao(b,c,e,g){return b.slice(0,c).concat(g).concat
-(b.slice(c+e))}i.prototype.GetListItems=function(k,n){var c=this.aE(k),b;for(b=0;b<c.length;b++){var e=c[b];if((e.v==23
-||e.v==15||e.v==22)&&e.C){c=ao(c,b,1,e.C);b--;continue}if(n<e.ay)break}b--;if(b<0)return null;var h=c[b];if(h.v!=21&&h.v
-!=20)return null;var g=[],m=h.C;for(var j=0;j<m.length;j++)g.push(m[j].ay);b++;if(b<c.length)g.push(c[b].ay);else g.push
-(k.length);return g};i.prototype.Transform=function(c){var n=c.indexOf("\r");if(n>=0){var m=c.indexOf("\n");if(m>=0)if(m
-<n)c=c.replace(/\n\r/g,"\n");else c=c.replace(/\r\n/g,"\n");c=c.replace(/\r/g,"\n")}this.HeadBlockContent="";var k=this.
-aE(c);if(this.bn!=null){var j=[];for(var r in this.bn)j.push(this.bn[r]);j.sort(function(p,q){return q.Abbr.length-p.
-Abbr.length});this.bn=j}var b=this.bF;b.K();for(var g=0;g<k.length;g++){var s=k[g];s.l(this,b)}if(this.bI.length>0){b.x(
-'\n<div class="');b.x(this.HtmlClassFootnotes);b.x('">\n');b.x("<hr />\n");b.x("<ol>\n");for(var g=0;g<this.bI.length;
+ExtractHeadBlocks:false,HeadBlockContent:"",EasyLineBreaks:false};var a=i.prototype;function ao(b,c,e,g){return b.slice(
+0,c).concat(g).concat(b.slice(c+e))}i.prototype.GetListItems=function(k,n){var c=this.aE(k),b;for(b=0;b<c.length;b++){
+var e=c[b];if((e.v==23||e.v==15||e.v==22)&&e.C){c=ao(c,b,1,e.C);b--;continue}if(n<e.ay)break}b--;if(b<0)return null;var 
+h=c[b];if(h.v!=21&&h.v!=20)return null;var g=[],m=h.C;for(var j=0;j<m.length;j++)g.push(m[j].ay);b++;if(b<c.length)g.
+push(c[b].ay);else g.push(k.length);return g};i.prototype.Transform=function(c){if(this.EasyLineBreaks)c=c.replace(
+/^([\w\*\>\<\[][^\r\n]*)(?=\r?\n[\w\*\>\<\[].*$)/gm,"$1  ");var n=c.indexOf("\r");if(n>=0){var m=c.indexOf("\n");if(m>=0
+)if(m<n)c=c.replace(/\n\r/g,"\n");else c=c.replace(/\r\n/g,"\n");c=c.replace(/\r/g,"\n")}this.HeadBlockContent="";var k=
+this.aE(c);if(this.bn!=null){var j=[];for(var r in this.bn)j.push(this.bn[r]);j.sort(function(p,q){return q.Abbr.length-
+p.Abbr.length});this.bn=j}var b=this.bF;b.K();for(var g=0;g<k.length;g++){var s=k[g];s.l(this,b)}if(this.bI.length>0){b.
+x('\n<div class="');b.x(this.HtmlClassFootnotes);b.x('">\n');b.x("<hr />\n");b.x("<ol>\n");for(var g=0;g<this.bI.length;
 g++){var h=this.bI[g];b.x('<li id="#fn:');b.x(h.X);b.x('">\n');var o='<a href="#fnref:'+h.X+
 '" rev="footnote">&#8617;</a>',e=h.C[h.C.length-1];if(e.v==12){e.v=29;e.X=o}else{e=new B();e.N=0;e.v=29;e.X=o;h.C.push(e
 )}h.l(this,b);b.x("</li>\n")}b.x("</ol\n");b.x("</div>\n")}return b.bh()};i.prototype.OnQualifyUrl=function(b){if(aj(b))

--- a/MarkdownDeepJS/MarkdownDeepEditorUI.min.js
+++ b/MarkdownDeepJS/MarkdownDeepEditorUI.min.js
@@ -26,24 +26,24 @@ var MarkdownDeepEditorUI=new(function(){this.HelpHtmlWritten=false;this.HelpHtml
 '<li><a href="#" class="mdd_button" id="mdd_link" title="Insert Hyperlink (Ctrl+L)" tabindex=-1></a></li>\n';a+=
 '<li><a href="#" class="mdd_button" id="mdd_img" title="Insert Image (Ctrl+G)" tabindex=-1></a></li>\n';a+=
 '<li><a href="#" class="mdd_button" id="mdd_hr" title="Insert Horizontal Rule (Ctrl+R)" tabindex=-1></a></li>\n';a+=
-"</ul>\n";a+='<div style="clear:both"></div>\n';return a};this.onResizerMouseDown=function(b){var d=$(b.srcElement).
-prevAll("textarea")[0],j=b.clientY,g=$(d).height();$(document).bind("mousemove.mdd",e);$(document).bind("mouseup.mdd",f)
-;return false;function f(a){$(document).unbind("mousemove.mdd");$(document).unbind("mouseup.mdd");return false}function 
-e(c){var a=g+c.clientY-j;if(a<50)a=50;$(d).height(a);return false}};var i=0,h=false;this.onShowHelpPopup=function(){$(
-"#mdd_syntax_container").fadeIn("fast");$(".modal_content").scrollTop(i);$(document).bind("keydown.mdd",function(j){if(j
-.keyCode==27){MarkdownDeepEditorUI.onCloseHelpPopup();return false}});if(!h){h=true;var a=$("#mdd_help_location").attr(
-"href");if(!a)a="mdd_help.htm";$("#mdd_syntax").load(a)}return false};this.onCloseHelpPopup=function(){i=$(
-".modal_content").scrollTop();$("#mdd_syntax_container").fadeOut("fast");$(document).unbind("keydown.mdd");$(document).
-unbind("scroll.mdd");return false};this.onToolbarButton=function(a){var b=$(a.target).closest("div.mdd_toolbar").nextAll
-("textarea.mdd_editor").data("mdd");b.InvokeCommand($(a.target).attr("id").substr(4));return false}})();(function(a){a.
-fn.MarkdownDeep=function(d){var f={resizebar:true,toolbar:true,help_location:"mdd_help.html"};if(d)a.extend(f,d);
-return this.each(function(){if(f.toolbar){var c=a(this).prev(".mdd_toolbar");if(c.length==0){c=a(
-'<div class="mdd_toolbar">'+MarkdownDeepEditorUI.ToolbarHtml()+"</div>");c.insertBefore(this)}else c.append(a(
-MarkdownDeepEditorUI.ToolbarHtml()));a("a.mdd_button",c).click(MarkdownDeepEditorUI.onToolbarButton);a("a.mdd_help",c).
-click(MarkdownDeepEditorUI.onShowHelpPopup);if(!MarkdownDeepEditorUI.HelpHtmlWritten){var i=a(MarkdownDeepEditorUI.
-HelpHtml(f.help_location));i.appendTo(a("body"));a("#mdd_close_help").click(MarkdownDeepEditorUI.onCloseHelpPopup);
-MarkdownDeepEditorUI.HelpHtmlWritten=true}}var b;if(f.resizebar){b=a(this).next(".mdd_resizer");if(b.length==0){b=a(
-'<div class="mdd_resizer"></div>');b.insertAfter(this)}b.bind("mousedown",MarkdownDeepEditorUI.onResizerMouseDown)}var h
-=a(this).attr("data-mdd-preview");if(!h)h=".mdd_preview";var g=a(h)[0];if(!g){a('<div class="mdd_preview"></div>').
-insertAfter(b?b:this);g=a(".mdd_preview")[0]}var e=new MarkdownDeepEditor.Editor(this,g);if(d){jQuery.extend(e.Markdown,
-d);jQuery.extend(e,d)}e.onOptionsChanged();a(this).data("mdd",e)})}})(jQuery)
+"</ul>\n";a+='<div style="clear:both"></div>\n';return a};this.onResizerMouseDown=function(a){var h=window.event?a.
+srcElement:a.target,f=$(h).prevAll("textarea")[0],l=a.clientY,k=$(f).height();$(document).bind("mousemove.mdd",e);$(
+document).bind("mouseup.mdd",g);return false;function g(b){$(document).unbind("mousemove.mdd");$(document).unbind(
+"mouseup.mdd");return false}function e(c){var b=k+c.clientY-l;if(b<50)b=50;$(f).height(b);return false}};var j=0,i=false
+;this.onShowHelpPopup=function(){$("#mdd_syntax_container").fadeIn("fast");$(".modal_content").scrollTop(j);$(document).
+bind("keydown.mdd",function(k){if(k.keyCode==27){MarkdownDeepEditorUI.onCloseHelpPopup();return false}});if(!i){i=true;
+var a=$("#mdd_help_location").attr("href");if(!a)a="mdd_help.htm";$("#mdd_syntax").load(a)}return false};this.
+onCloseHelpPopup=function(){j=$(".modal_content").scrollTop();$("#mdd_syntax_container").fadeOut("fast");$(document).
+unbind("keydown.mdd");$(document).unbind("scroll.mdd");return false};this.onToolbarButton=function(a){var b=$(a.target).
+closest("div.mdd_toolbar").nextAll("textarea.mdd_editor").data("mdd");b.InvokeCommand($(a.target).attr("id").substr(4));
+return false}})();(function(a){a.fn.MarkdownDeep=function(d){var f={resizebar:true,toolbar:true,help_location:
+"mdd_help.html"};if(d)a.extend(f,d);return this.each(function(){if(f.toolbar){var c=a(this).prev(".mdd_toolbar");if(c.
+length==0){c=a('<div class="mdd_toolbar">'+MarkdownDeepEditorUI.ToolbarHtml()+"</div>");c.insertBefore(this)}else c.
+append(a(MarkdownDeepEditorUI.ToolbarHtml()));a("a.mdd_button",c).click(MarkdownDeepEditorUI.onToolbarButton);a(
+"a.mdd_help",c).click(MarkdownDeepEditorUI.onShowHelpPopup);if(!MarkdownDeepEditorUI.HelpHtmlWritten){var i=a(
+MarkdownDeepEditorUI.HelpHtml(f.help_location));i.appendTo(a("body"));a("#mdd_close_help").click(MarkdownDeepEditorUI.
+onCloseHelpPopup);MarkdownDeepEditorUI.HelpHtmlWritten=true}}var b;if(f.resizebar){b=a(this).next(".mdd_resizer");if(b.
+length==0){b=a('<div class="mdd_resizer"></div>');b.insertAfter(this)}b.bind("mousedown",MarkdownDeepEditorUI.
+onResizerMouseDown)}var h=a(this).attr("data-mdd-preview");if(!h)h=".mdd_preview";var g=a(h)[0];if(!g){a(
+'<div class="mdd_preview"></div>').insertAfter(b?b:this);g=a(".mdd_preview")[0]}var e=new MarkdownDeepEditor.Editor(this
+,g);if(d){jQuery.extend(e.Markdown,d);jQuery.extend(e,d)}e.onOptionsChanged();a(this).data("mdd",e)})}})(jQuery)

--- a/MarkdownDeepJS/MarkdownDeepLib.min.js
+++ b/MarkdownDeepJS/MarkdownDeepLib.min.js
@@ -6,15 +6,16 @@ if(b[c]===e)return c;return-1}function i(){this.bz=new E(this);this.bC=[];this.b
 SafeMode:false,ExtraMode:false,MarkdownInHtml:false,AutoHeadingIDs:false,UrlBaseLocation:null,UrlRootLocation:null,
 NewWindowForExternalLinks:false,NewWindowForLocalLinks:false,NoFollowLinks:false,HtmlClassFootnotes:"footnotes",
 HtmlClassTitledImages:null,RenderingTitledImage:false,FormatCodeBlockAttributes:null,FormatCodeBlock:null,
-ExtractHeadBlocks:false,HeadBlockContent:""};var a=i.prototype;function ao(b,c,e,g){return b.slice(0,c).concat(g).concat
-(b.slice(c+e))}i.prototype.GetListItems=function(k,n){var c=this.aE(k),b;for(b=0;b<c.length;b++){var e=c[b];if((e.v==23
-||e.v==15||e.v==22)&&e.C){c=ao(c,b,1,e.C);b--;continue}if(n<e.ay)break}b--;if(b<0)return null;var h=c[b];if(h.v!=21&&h.v
-!=20)return null;var g=[],m=h.C;for(var j=0;j<m.length;j++)g.push(m[j].ay);b++;if(b<c.length)g.push(c[b].ay);else g.push
-(k.length);return g};i.prototype.Transform=function(c){var n=c.indexOf("\r");if(n>=0){var m=c.indexOf("\n");if(m>=0)if(m
-<n)c=c.replace(/\n\r/g,"\n");else c=c.replace(/\r\n/g,"\n");c=c.replace(/\r/g,"\n")}this.HeadBlockContent="";var k=this.
-aE(c);if(this.bn!=null){var j=[];for(var r in this.bn)j.push(this.bn[r]);j.sort(function(p,q){return q.Abbr.length-p.
-Abbr.length});this.bn=j}var b=this.bF;b.K();for(var g=0;g<k.length;g++){var s=k[g];s.l(this,b)}if(this.bI.length>0){b.x(
-'\n<div class="');b.x(this.HtmlClassFootnotes);b.x('">\n');b.x("<hr />\n");b.x("<ol>\n");for(var g=0;g<this.bI.length;
+ExtractHeadBlocks:false,HeadBlockContent:"",EasyLineBreaks:false};var a=i.prototype;function ao(b,c,e,g){return b.slice(
+0,c).concat(g).concat(b.slice(c+e))}i.prototype.GetListItems=function(k,n){var c=this.aE(k),b;for(b=0;b<c.length;b++){
+var e=c[b];if((e.v==23||e.v==15||e.v==22)&&e.C){c=ao(c,b,1,e.C);b--;continue}if(n<e.ay)break}b--;if(b<0)return null;var 
+h=c[b];if(h.v!=21&&h.v!=20)return null;var g=[],m=h.C;for(var j=0;j<m.length;j++)g.push(m[j].ay);b++;if(b<c.length)g.
+push(c[b].ay);else g.push(k.length);return g};i.prototype.Transform=function(c){if(this.EasyLineBreaks)c=c.replace(
+/^([\w\*\>\<\[][^\r\n]*)(?=\r?\n[\w\*\>\<\[].*$)/gm,"$1  ");var n=c.indexOf("\r");if(n>=0){var m=c.indexOf("\n");if(m>=0
+)if(m<n)c=c.replace(/\n\r/g,"\n");else c=c.replace(/\r\n/g,"\n");c=c.replace(/\r/g,"\n")}this.HeadBlockContent="";var k=
+this.aE(c);if(this.bn!=null){var j=[];for(var r in this.bn)j.push(this.bn[r]);j.sort(function(p,q){return q.Abbr.length-
+p.Abbr.length});this.bn=j}var b=this.bF;b.K();for(var g=0;g<k.length;g++){var s=k[g];s.l(this,b)}if(this.bI.length>0){b.
+x('\n<div class="');b.x(this.HtmlClassFootnotes);b.x('">\n');b.x("<hr />\n");b.x("<ol>\n");for(var g=0;g<this.bI.length;
 g++){var h=this.bI[g];b.x('<li id="#fn:');b.x(h.X);b.x('">\n');var o='<a href="#fnref:'+h.X+
 '" rev="footnote">&#8617;</a>',e=h.C[h.C.length-1];if(e.v==12){e.v=29;e.X=o}else{e=new B();e.N=0;e.v=29;e.X=o;h.C.push(e
 )}h.l(this,b);b.x("</li>\n")}b.x("</ol\n");b.x("</div>\n")}return b.bh()};i.prototype.OnQualifyUrl=function(b){if(aj(b))
@@ -415,24 +416,24 @@ var MarkdownDeepEditorUI=new(function(){this.HelpHtmlWritten=false;this.HelpHtml
 '<li><a href="#" class="mdd_button" id="mdd_link" title="Insert Hyperlink (Ctrl+L)" tabindex=-1></a></li>\n';a+=
 '<li><a href="#" class="mdd_button" id="mdd_img" title="Insert Image (Ctrl+G)" tabindex=-1></a></li>\n';a+=
 '<li><a href="#" class="mdd_button" id="mdd_hr" title="Insert Horizontal Rule (Ctrl+R)" tabindex=-1></a></li>\n';a+=
-"</ul>\n";a+='<div style="clear:both"></div>\n';return a};this.onResizerMouseDown=function(b){var d=$(b.srcElement).
-prevAll("textarea")[0],j=b.clientY,g=$(d).height();$(document).bind("mousemove.mdd",e);$(document).bind("mouseup.mdd",f)
-;return false;function f(a){$(document).unbind("mousemove.mdd");$(document).unbind("mouseup.mdd");return false}function 
-e(c){var a=g+c.clientY-j;if(a<50)a=50;$(d).height(a);return false}};var i=0,h=false;this.onShowHelpPopup=function(){$(
-"#mdd_syntax_container").fadeIn("fast");$(".modal_content").scrollTop(i);$(document).bind("keydown.mdd",function(j){if(j
-.keyCode==27){MarkdownDeepEditorUI.onCloseHelpPopup();return false}});if(!h){h=true;var a=$("#mdd_help_location").attr(
-"href");if(!a)a="mdd_help.htm";$("#mdd_syntax").load(a)}return false};this.onCloseHelpPopup=function(){i=$(
-".modal_content").scrollTop();$("#mdd_syntax_container").fadeOut("fast");$(document).unbind("keydown.mdd");$(document).
-unbind("scroll.mdd");return false};this.onToolbarButton=function(a){var b=$(a.target).closest("div.mdd_toolbar").nextAll
-("textarea.mdd_editor").data("mdd");b.InvokeCommand($(a.target).attr("id").substr(4));return false}})();(function(a){a.
-fn.MarkdownDeep=function(d){var f={resizebar:true,toolbar:true,help_location:"mdd_help.html"};if(d)a.extend(f,d);
-return this.each(function(){if(f.toolbar){var c=a(this).prev(".mdd_toolbar");if(c.length==0){c=a(
-'<div class="mdd_toolbar">'+MarkdownDeepEditorUI.ToolbarHtml()+"</div>");c.insertBefore(this)}else c.append(a(
-MarkdownDeepEditorUI.ToolbarHtml()));a("a.mdd_button",c).click(MarkdownDeepEditorUI.onToolbarButton);a("a.mdd_help",c).
-click(MarkdownDeepEditorUI.onShowHelpPopup);if(!MarkdownDeepEditorUI.HelpHtmlWritten){var i=a(MarkdownDeepEditorUI.
-HelpHtml(f.help_location));i.appendTo(a("body"));a("#mdd_close_help").click(MarkdownDeepEditorUI.onCloseHelpPopup);
-MarkdownDeepEditorUI.HelpHtmlWritten=true}}var b;if(f.resizebar){b=a(this).next(".mdd_resizer");if(b.length==0){b=a(
-'<div class="mdd_resizer"></div>');b.insertAfter(this)}b.bind("mousedown",MarkdownDeepEditorUI.onResizerMouseDown)}var h
-=a(this).attr("data-mdd-preview");if(!h)h=".mdd_preview";var g=a(h)[0];if(!g){a('<div class="mdd_preview"></div>').
-insertAfter(b?b:this);g=a(".mdd_preview")[0]}var e=new MarkdownDeepEditor.Editor(this,g);if(d){jQuery.extend(e.Markdown,
-d);jQuery.extend(e,d)}e.onOptionsChanged();a(this).data("mdd",e)})}})(jQuery)
+"</ul>\n";a+='<div style="clear:both"></div>\n';return a};this.onResizerMouseDown=function(a){var h=window.event?a.
+srcElement:a.target,f=$(h).prevAll("textarea")[0],l=a.clientY,k=$(f).height();$(document).bind("mousemove.mdd",e);$(
+document).bind("mouseup.mdd",g);return false;function g(b){$(document).unbind("mousemove.mdd");$(document).unbind(
+"mouseup.mdd");return false}function e(c){var b=k+c.clientY-l;if(b<50)b=50;$(f).height(b);return false}};var j=0,i=false
+;this.onShowHelpPopup=function(){$("#mdd_syntax_container").fadeIn("fast");$(".modal_content").scrollTop(j);$(document).
+bind("keydown.mdd",function(k){if(k.keyCode==27){MarkdownDeepEditorUI.onCloseHelpPopup();return false}});if(!i){i=true;
+var a=$("#mdd_help_location").attr("href");if(!a)a="mdd_help.htm";$("#mdd_syntax").load(a)}return false};this.
+onCloseHelpPopup=function(){j=$(".modal_content").scrollTop();$("#mdd_syntax_container").fadeOut("fast");$(document).
+unbind("keydown.mdd");$(document).unbind("scroll.mdd");return false};this.onToolbarButton=function(a){var b=$(a.target).
+closest("div.mdd_toolbar").nextAll("textarea.mdd_editor").data("mdd");b.InvokeCommand($(a.target).attr("id").substr(4));
+return false}})();(function(a){a.fn.MarkdownDeep=function(d){var f={resizebar:true,toolbar:true,help_location:
+"mdd_help.html"};if(d)a.extend(f,d);return this.each(function(){if(f.toolbar){var c=a(this).prev(".mdd_toolbar");if(c.
+length==0){c=a('<div class="mdd_toolbar">'+MarkdownDeepEditorUI.ToolbarHtml()+"</div>");c.insertBefore(this)}else c.
+append(a(MarkdownDeepEditorUI.ToolbarHtml()));a("a.mdd_button",c).click(MarkdownDeepEditorUI.onToolbarButton);a(
+"a.mdd_help",c).click(MarkdownDeepEditorUI.onShowHelpPopup);if(!MarkdownDeepEditorUI.HelpHtmlWritten){var i=a(
+MarkdownDeepEditorUI.HelpHtml(f.help_location));i.appendTo(a("body"));a("#mdd_close_help").click(MarkdownDeepEditorUI.
+onCloseHelpPopup);MarkdownDeepEditorUI.HelpHtmlWritten=true}}var b;if(f.resizebar){b=a(this).next(".mdd_resizer");if(b.
+length==0){b=a('<div class="mdd_resizer"></div>');b.insertAfter(this)}b.bind("mousedown",MarkdownDeepEditorUI.
+onResizerMouseDown)}var h=a(this).attr("data-mdd-preview");if(!h)h=".mdd_preview";var g=a(h)[0];if(!g){a(
+'<div class="mdd_preview"></div>').insertAfter(b?b:this);g=a(".mdd_preview")[0]}var e=new MarkdownDeepEditor.Editor(this
+,g);if(d){jQuery.extend(e.Markdown,d);jQuery.extend(e,d)}e.onOptionsChanged();a(this).data("mdd",e)})}})(jQuery)


### PR DESCRIPTION
This is achieved by pre-processing the text with a regex before transforming it in the usual way.

The option is called EasyLineBreaks, and has been implemented for client and server.
