### PR TITLE
Update corresponding preview section when multiple editors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ Debug
 *.zip
 *.nupkg
 /packages/*
+*[Rr]esharper*

--- a/MarkdownDeepJS/MarkdownDeepEditorUI.js
+++ b/MarkdownDeepJS/MarkdownDeepEditorUI.js
@@ -274,7 +274,7 @@ How the associated UI components are located:
     }
 
     // Create each markdown editor
-    return this.each(function() {        
+    return this.each(function(index) {        
         // Check if our textarea is encased in a wrapper div
         var editorwrap = $(this).parent(".mdd_editor_wrap");
         if (editorwrap.length==0) {
@@ -350,11 +350,11 @@ How the associated UI components are located:
         var preview_selector=$(this).attr("data-mdd-preview");
         if (!preview_selector)
              preview_selector=".mdd_preview";
-        var preview=$(preview_selector)[0];
+        var preview=$(preview_selector)[index];
         if (!preview)
         {
             $("<div class=\"mdd_preview\"></div>").insertAfter(resizer ? resizer : this);
-            preview=$(".mdd_preview")[0];
+            preview=$(".mdd_preview")[index];
         }
         
         // Create the editor helper

--- a/MarkdownDeepJS/MarkdownDeepEditorUI.min.js
+++ b/MarkdownDeepJS/MarkdownDeepEditorUI.min.js
@@ -38,17 +38,17 @@ onCloseHelpPopup();return false}});if(!i){i=true;var a=$("#mdd_help_location").a
 };this.onToolbarButton=function(a){var b=$(a.target).closest("div.mdd_toolbar_wrap").next(".mdd_editor_wrap").children(
 "textarea").data("mdd");b.InvokeCommand($(a.target).attr("id").substr(4));return false}})();(function(a){a.fn.
 MarkdownDeep=function(f){var h={resizebar:true,toolbar:true,help_location:"mdd_help.html"};if(f)a.extend(h,f);
-return this.each(function(){var d=a(this).parent(".mdd_editor_wrap");if(d.length==0)d=a(this).wrap(
+return this.each(function(l){var d=a(this).parent(".mdd_editor_wrap");if(d.length==0)d=a(this).wrap(
 '<div class="mdd_editor_wrap" />').parent();if(h.toolbar){var k=d.prev(".mdd_toolbar_wrap"),c=d.prev(".mdd_toolbar");if(
 k.length==0){if(c.length==0){c=a('<div class="mdd_toolbar" />');c.insertBefore(d)}k=c.wrap(
 '<div class="mdd_toolbar_wrap" />').parent()}else if(c.length==0){c=a('<div class="mdd_toolbar" />');k.html(c)}c.append(
 a(MarkdownDeepEditorUI.ToolbarHtml()));a("a.mdd_button",c).click(MarkdownDeepEditorUI.onToolbarButton);a("a.mdd_help",c)
-.click(MarkdownDeepEditorUI.onShowHelpPopup);if(!MarkdownDeepEditorUI.HelpHtmlWritten){var l=a(MarkdownDeepEditorUI.
-HelpHtml(h.help_location));l.appendTo(a("body"));a("#mdd_close_help").click(MarkdownDeepEditorUI.onCloseHelpPopup);
+.click(MarkdownDeepEditorUI.onShowHelpPopup);if(!MarkdownDeepEditorUI.HelpHtmlWritten){var m=a(MarkdownDeepEditorUI.
+HelpHtml(h.help_location));m.appendTo(a("body"));a("#mdd_close_help").click(MarkdownDeepEditorUI.onCloseHelpPopup);
 MarkdownDeepEditorUI.HelpHtmlWritten=true}}var b,e;if(h.resizebar){e=d.next(".mdd_resizer_wrap"),b=e.length==0?d.next(
 ".mdd_resizer"):e.children(".mdd_resizer");if(e.length==0){if(b.length==0){b=a('<div class="mdd_resizer" />');b.
 insertAfter(d)}e=b.wrap('<div class="mdd_resizer_wrap" />').parent()}else if(b.length==0){b=a(
 '<div class="mdd_resizer" />');e.html(b)}e.bind("mousedown",MarkdownDeepEditorUI.onResizerMouseDown)}var j=a(this).attr(
-"data-mdd-preview");if(!j)j=".mdd_preview";var i=a(j)[0];if(!i){a('<div class="mdd_preview"></div>').insertAfter(b?b:
-this);i=a(".mdd_preview")[0]}var g=new MarkdownDeepEditor.Editor(this,i);if(f){jQuery.extend(g.Markdown,f);jQuery.extend
+"data-mdd-preview");if(!j)j=".mdd_preview";var i=a(j)[l];if(!i){a('<div class="mdd_preview"></div>').insertAfter(b?b:
+this);i=a(".mdd_preview")[l]}var g=new MarkdownDeepEditor.Editor(this,i);if(f){jQuery.extend(g.Markdown,f);jQuery.extend
 (g,f)}g.onOptionsChanged();a(this).data("mdd",g)})}})(jQuery)

--- a/MarkdownDeepJS/MarkdownDeepLib.min.js
+++ b/MarkdownDeepJS/MarkdownDeepLib.min.js
@@ -427,17 +427,17 @@ onCloseHelpPopup();return false}});if(!i){i=true;var a=$("#mdd_help_location").a
 };this.onToolbarButton=function(a){var b=$(a.target).closest("div.mdd_toolbar_wrap").next(".mdd_editor_wrap").children(
 "textarea").data("mdd");b.InvokeCommand($(a.target).attr("id").substr(4));return false}})();(function(a){a.fn.
 MarkdownDeep=function(f){var h={resizebar:true,toolbar:true,help_location:"mdd_help.html"};if(f)a.extend(h,f);
-return this.each(function(){var d=a(this).parent(".mdd_editor_wrap");if(d.length==0)d=a(this).wrap(
+return this.each(function(l){var d=a(this).parent(".mdd_editor_wrap");if(d.length==0)d=a(this).wrap(
 '<div class="mdd_editor_wrap" />').parent();if(h.toolbar){var k=d.prev(".mdd_toolbar_wrap"),c=d.prev(".mdd_toolbar");if(
 k.length==0){if(c.length==0){c=a('<div class="mdd_toolbar" />');c.insertBefore(d)}k=c.wrap(
 '<div class="mdd_toolbar_wrap" />').parent()}else if(c.length==0){c=a('<div class="mdd_toolbar" />');k.html(c)}c.append(
 a(MarkdownDeepEditorUI.ToolbarHtml()));a("a.mdd_button",c).click(MarkdownDeepEditorUI.onToolbarButton);a("a.mdd_help",c)
-.click(MarkdownDeepEditorUI.onShowHelpPopup);if(!MarkdownDeepEditorUI.HelpHtmlWritten){var l=a(MarkdownDeepEditorUI.
-HelpHtml(h.help_location));l.appendTo(a("body"));a("#mdd_close_help").click(MarkdownDeepEditorUI.onCloseHelpPopup);
+.click(MarkdownDeepEditorUI.onShowHelpPopup);if(!MarkdownDeepEditorUI.HelpHtmlWritten){var m=a(MarkdownDeepEditorUI.
+HelpHtml(h.help_location));m.appendTo(a("body"));a("#mdd_close_help").click(MarkdownDeepEditorUI.onCloseHelpPopup);
 MarkdownDeepEditorUI.HelpHtmlWritten=true}}var b,e;if(h.resizebar){e=d.next(".mdd_resizer_wrap"),b=e.length==0?d.next(
 ".mdd_resizer"):e.children(".mdd_resizer");if(e.length==0){if(b.length==0){b=a('<div class="mdd_resizer" />');b.
 insertAfter(d)}e=b.wrap('<div class="mdd_resizer_wrap" />').parent()}else if(b.length==0){b=a(
 '<div class="mdd_resizer" />');e.html(b)}e.bind("mousedown",MarkdownDeepEditorUI.onResizerMouseDown)}var j=a(this).attr(
-"data-mdd-preview");if(!j)j=".mdd_preview";var i=a(j)[0];if(!i){a('<div class="mdd_preview"></div>').insertAfter(b?b:
-this);i=a(".mdd_preview")[0]}var g=new MarkdownDeepEditor.Editor(this,i);if(f){jQuery.extend(g.Markdown,f);jQuery.extend
+"data-mdd-preview");if(!j)j=".mdd_preview";var i=a(j)[l];if(!i){a('<div class="mdd_preview"></div>').insertAfter(b?b:
+this);i=a(".mdd_preview")[l]}var g=new MarkdownDeepEditor.Editor(this,i);if(f){jQuery.extend(g.Markdown,f);jQuery.extend
 (g,f)}g.onOptionsChanged();a(this).data("mdd",g)})}})(jQuery)

--- a/MarkdownDeepSample/Controllers/MarkdownDeepController.cs
+++ b/MarkdownDeepSample/Controllers/MarkdownDeepController.cs
@@ -27,6 +27,18 @@ This demo project shows how to use MarkdownDeep in a typical ASP.NET MVC applica
 MarkdownDeep is written by [Topten Software](http://www.toptensoftware.com).  The project home for MarkdownDeep is [here](http://www.toptensoftware.com/markdowndeep).
 
 ";
+        static string m_Content2 =
+@"# Edit this second field with MarkdownDeep
+
+This demo project shows how to use MarkdownDeep in a typical ASP.NET MVC application.
+
+* Click the *Edit this Page* link below to make changes to this page with MarkdownDeep's editor
+* Use the links in the top right for more info.
+* Look at the file `MarkdownDeepController.cs` for implementation details.
+
+MarkdownDeep is written by [Topten Software](http://www.toptensoftware.com).  The project home for MarkdownDeep is [here](http://www.toptensoftware.com/markdowndeep).
+
+";
 
 		public ActionResult Index()
 		{
@@ -76,5 +88,38 @@ MarkdownDeep is written by [Topten Software](http://www.toptensoftware.com).  Th
 
 			return View();
 		}
+
+        public ActionResult Multiple()
+        {
+            // View the user editable content
+
+            // Create and setup Markdown translator
+            var md = new MarkdownDeep.Markdown();
+            md.SafeMode = true;
+            md.ExtraMode = true;
+
+            // Transform the content and pass to the view
+            ViewData["Content"] = md.Transform(m_Content);
+            ViewData["Content2"] = md.Transform(m_Content2);
+            return View();
+        }
+
+        [AcceptVerbs(HttpVerbs.Get)]
+        public ActionResult MultipleEdit()
+        {
+            // For editing the content, just pass the raw Markdown to the view
+            ViewData["content"] = m_Content;
+            ViewData["content2"] = m_Content2;
+            return View();
+        }
+
+        [AcceptVerbs(HttpVerbs.Post)]
+        public ActionResult MultipleEdit(string content, string content2)
+        {
+            // Save the content and switch back to the main view
+            m_Content = content;
+            m_Content2 = content2;
+            return RedirectToAction("Multiple");
+        }
 	}
 }

--- a/MarkdownDeepSample/MarkdownDeepSample.csproj
+++ b/MarkdownDeepSample/MarkdownDeepSample.csproj
@@ -89,6 +89,8 @@
     <Content Include="Scripts\mdd_styles.css" />
     <Content Include="Scripts\mdd_toolbar.png" />
     <Content Include="Views\MarkdownDeep\Edit.aspx" />
+    <Content Include="Views\MarkdownDeep\Multiple.aspx" />
+    <Content Include="Views\MarkdownDeep\MultipleEdit.aspx" />
     <Content Include="Views\MarkdownDeep\QuickRef.aspx" />
     <Content Include="Web.config" />
     <Content Include="Web.Debug.config">

--- a/MarkdownDeepSample/Scripts/MarkdownDeepLib.min.js
+++ b/MarkdownDeepSample/Scripts/MarkdownDeepLib.min.js
@@ -427,17 +427,17 @@ onCloseHelpPopup();return false}});if(!i){i=true;var a=$("#mdd_help_location").a
 };this.onToolbarButton=function(a){var b=$(a.target).closest("div.mdd_toolbar_wrap").next(".mdd_editor_wrap").children(
 "textarea").data("mdd");b.InvokeCommand($(a.target).attr("id").substr(4));return false}})();(function(a){a.fn.
 MarkdownDeep=function(f){var h={resizebar:true,toolbar:true,help_location:"mdd_help.html"};if(f)a.extend(h,f);
-return this.each(function(){var d=a(this).parent(".mdd_editor_wrap");if(d.length==0)d=a(this).wrap(
+return this.each(function(l){var d=a(this).parent(".mdd_editor_wrap");if(d.length==0)d=a(this).wrap(
 '<div class="mdd_editor_wrap" />').parent();if(h.toolbar){var k=d.prev(".mdd_toolbar_wrap"),c=d.prev(".mdd_toolbar");if(
 k.length==0){if(c.length==0){c=a('<div class="mdd_toolbar" />');c.insertBefore(d)}k=c.wrap(
 '<div class="mdd_toolbar_wrap" />').parent()}else if(c.length==0){c=a('<div class="mdd_toolbar" />');k.html(c)}c.append(
 a(MarkdownDeepEditorUI.ToolbarHtml()));a("a.mdd_button",c).click(MarkdownDeepEditorUI.onToolbarButton);a("a.mdd_help",c)
-.click(MarkdownDeepEditorUI.onShowHelpPopup);if(!MarkdownDeepEditorUI.HelpHtmlWritten){var l=a(MarkdownDeepEditorUI.
-HelpHtml(h.help_location));l.appendTo(a("body"));a("#mdd_close_help").click(MarkdownDeepEditorUI.onCloseHelpPopup);
+.click(MarkdownDeepEditorUI.onShowHelpPopup);if(!MarkdownDeepEditorUI.HelpHtmlWritten){var m=a(MarkdownDeepEditorUI.
+HelpHtml(h.help_location));m.appendTo(a("body"));a("#mdd_close_help").click(MarkdownDeepEditorUI.onCloseHelpPopup);
 MarkdownDeepEditorUI.HelpHtmlWritten=true}}var b,e;if(h.resizebar){e=d.next(".mdd_resizer_wrap"),b=e.length==0?d.next(
 ".mdd_resizer"):e.children(".mdd_resizer");if(e.length==0){if(b.length==0){b=a('<div class="mdd_resizer" />');b.
 insertAfter(d)}e=b.wrap('<div class="mdd_resizer_wrap" />').parent()}else if(b.length==0){b=a(
 '<div class="mdd_resizer" />');e.html(b)}e.bind("mousedown",MarkdownDeepEditorUI.onResizerMouseDown)}var j=a(this).attr(
-"data-mdd-preview");if(!j)j=".mdd_preview";var i=a(j)[0];if(!i){a('<div class="mdd_preview"></div>').insertAfter(b?b:
-this);i=a(".mdd_preview")[0]}var g=new MarkdownDeepEditor.Editor(this,i);if(f){jQuery.extend(g.Markdown,f);jQuery.extend
+"data-mdd-preview");if(!j)j=".mdd_preview";var i=a(j)[l];if(!i){a('<div class="mdd_preview"></div>').insertAfter(b?b:
+this);i=a(".mdd_preview")[l]}var g=new MarkdownDeepEditor.Editor(this,i);if(f){jQuery.extend(g.Markdown,f);jQuery.extend
 (g,f)}g.onOptionsChanged();a(this).data("mdd",g)})}})(jQuery)

--- a/MarkdownDeepSample/Views/MarkdownDeep/MarkdownDeep.Master
+++ b/MarkdownDeepSample/Views/MarkdownDeep/MarkdownDeep.Master
@@ -21,6 +21,7 @@
                 <ul id="menu">              
                     <li><%: Html.ActionLink("Home", "Index", "MarkdownDeep")%></li>
                     <li><%: Html.ActionLink("Quick Reference", "QuickRef", "MarkdownDeep")%></li>
+                    <li><%: Html.ActionLink("Multiple Editors", "Multiple", "MarkdownDeep")%></li>
                     <li><%: Html.ActionLink("About", "About", "MarkdownDeep")%></li>
                 </ul>
             

--- a/MarkdownDeepSample/Views/MarkdownDeep/Multiple.aspx
+++ b/MarkdownDeepSample/Views/MarkdownDeep/Multiple.aspx
@@ -1,0 +1,10 @@
+﻿<%@ Page Language="C#" MasterPageFile="MarkdownDeep.Master" Inherits="System.Web.Mvc.ViewPage" %>
+
+<asp:Content ID="Content1" ContentPlaceHolderID="TitleContent" runat="server">
+    MarkdownDeep Multiple Editor Sample Page
+</asp:Content>
+<asp:Content ID="Content2" ContentPlaceHolderID="MainContent" runat="server">
+    <%=ViewData["Content"] %>
+    <%=ViewData["Content2"] %>
+    <p><%=Html.ActionLink("Edit this Page", "MultipleEdit") %></p>
+</asp:Content>

--- a/MarkdownDeepSample/Views/MarkdownDeep/MultipleEdit.aspx
+++ b/MarkdownDeepSample/Views/MarkdownDeep/MultipleEdit.aspx
@@ -1,0 +1,34 @@
+﻿<%@ Page Title="" Language="C#" MasterPageFile="~/Views/MarkdownDeep/MarkdownDeep.Master" Inherits="System.Web.Mvc.ViewPage<dynamic>" %>
+
+<asp:Content ID="Content1" ContentPlaceHolderID="TitleContent" runat="server">
+	Multiple
+</asp:Content>
+
+<asp:Content ID="Content2" ContentPlaceHolderID="HeadContent" runat="server">
+    <link rel="stylesheet" type="text/css" href="/Scripts/mdd_styles.css" />
+    <script type="text/javascript" src="/Scripts/jQuery-1.4.1.min.js"></script>
+    <script type="text/javascript" src="/Scripts/MarkdownDeepLib.min.js"></script>
+    <script type="text/javascript">
+        $(function () {
+            $("textarea.mdd_editor").MarkdownDeep({
+                help_location: "/Scripts/mdd_help.htm",
+                ExtraMode: true
+            });
+        })
+    </script>
+</asp:Content>
+
+<asp:Content ID="Content3" ContentPlaceHolderID="MainContent" runat="server">
+    <% using(Html.BeginForm()) { %>
+        <div class="mdd_toolbar"></div>
+        <%=Html.TextArea("content", new { @class="mdd_editor" }) %>
+        <div class="mdd_resizer"></div>
+        <div class="mdd_preview"></div>
+    
+        <div class="mdd_toolbar"></div>
+        <%=Html.TextArea("content2", new { @class="mdd_editor" }) %>
+        <div class="mdd_resizer"></div>
+
+        <p><input type="submit" value="Save" /></p>
+    <% } %>
+</asp:Content>

--- a/MarkdownDeepTests/JSTestResources/MarkdownDeepEditorUI.js
+++ b/MarkdownDeepTests/JSTestResources/MarkdownDeepEditorUI.js
@@ -274,7 +274,7 @@ How the associated UI components are located:
     }
 
     // Create each markdown editor
-    return this.each(function() {        
+    return this.each(function(index) {        
         // Check if our textarea is encased in a wrapper div
         var editorwrap = $(this).parent(".mdd_editor_wrap");
         if (editorwrap.length==0) {
@@ -350,11 +350,11 @@ How the associated UI components are located:
         var preview_selector=$(this).attr("data-mdd-preview");
         if (!preview_selector)
              preview_selector=".mdd_preview";
-        var preview=$(preview_selector)[0];
+        var preview=$(preview_selector)[index];
         if (!preview)
         {
             $("<div class=\"mdd_preview\"></div>").insertAfter(resizer ? resizer : this);
-            preview=$(".mdd_preview")[0];
+            preview=$(".mdd_preview")[index];
         }
         
         // Create the editor helper

--- a/MarkdownDeepTests/JSTestResources/MarkdownDeepEditorUI.min.js
+++ b/MarkdownDeepTests/JSTestResources/MarkdownDeepEditorUI.min.js
@@ -38,17 +38,17 @@ onCloseHelpPopup();return false}});if(!i){i=true;var a=$("#mdd_help_location").a
 };this.onToolbarButton=function(a){var b=$(a.target).closest("div.mdd_toolbar_wrap").next(".mdd_editor_wrap").children(
 "textarea").data("mdd");b.InvokeCommand($(a.target).attr("id").substr(4));return false}})();(function(a){a.fn.
 MarkdownDeep=function(f){var h={resizebar:true,toolbar:true,help_location:"mdd_help.html"};if(f)a.extend(h,f);
-return this.each(function(){var d=a(this).parent(".mdd_editor_wrap");if(d.length==0)d=a(this).wrap(
+return this.each(function(l){var d=a(this).parent(".mdd_editor_wrap");if(d.length==0)d=a(this).wrap(
 '<div class="mdd_editor_wrap" />').parent();if(h.toolbar){var k=d.prev(".mdd_toolbar_wrap"),c=d.prev(".mdd_toolbar");if(
 k.length==0){if(c.length==0){c=a('<div class="mdd_toolbar" />');c.insertBefore(d)}k=c.wrap(
 '<div class="mdd_toolbar_wrap" />').parent()}else if(c.length==0){c=a('<div class="mdd_toolbar" />');k.html(c)}c.append(
 a(MarkdownDeepEditorUI.ToolbarHtml()));a("a.mdd_button",c).click(MarkdownDeepEditorUI.onToolbarButton);a("a.mdd_help",c)
-.click(MarkdownDeepEditorUI.onShowHelpPopup);if(!MarkdownDeepEditorUI.HelpHtmlWritten){var l=a(MarkdownDeepEditorUI.
-HelpHtml(h.help_location));l.appendTo(a("body"));a("#mdd_close_help").click(MarkdownDeepEditorUI.onCloseHelpPopup);
+.click(MarkdownDeepEditorUI.onShowHelpPopup);if(!MarkdownDeepEditorUI.HelpHtmlWritten){var m=a(MarkdownDeepEditorUI.
+HelpHtml(h.help_location));m.appendTo(a("body"));a("#mdd_close_help").click(MarkdownDeepEditorUI.onCloseHelpPopup);
 MarkdownDeepEditorUI.HelpHtmlWritten=true}}var b,e;if(h.resizebar){e=d.next(".mdd_resizer_wrap"),b=e.length==0?d.next(
 ".mdd_resizer"):e.children(".mdd_resizer");if(e.length==0){if(b.length==0){b=a('<div class="mdd_resizer" />');b.
 insertAfter(d)}e=b.wrap('<div class="mdd_resizer_wrap" />').parent()}else if(b.length==0){b=a(
 '<div class="mdd_resizer" />');e.html(b)}e.bind("mousedown",MarkdownDeepEditorUI.onResizerMouseDown)}var j=a(this).attr(
-"data-mdd-preview");if(!j)j=".mdd_preview";var i=a(j)[0];if(!i){a('<div class="mdd_preview"></div>').insertAfter(b?b:
-this);i=a(".mdd_preview")[0]}var g=new MarkdownDeepEditor.Editor(this,i);if(f){jQuery.extend(g.Markdown,f);jQuery.extend
+"data-mdd-preview");if(!j)j=".mdd_preview";var i=a(j)[l];if(!i){a('<div class="mdd_preview"></div>').insertAfter(b?b:
+this);i=a(".mdd_preview")[l]}var g=new MarkdownDeepEditor.Editor(this,i);if(f){jQuery.extend(g.Markdown,f);jQuery.extend
 (g,f)}g.onOptionsChanged();a(this).data("mdd",g)})}})(jQuery)

--- a/MarkdownDeepTests/JSTestResources/MarkdownDeepLib.min.js
+++ b/MarkdownDeepTests/JSTestResources/MarkdownDeepLib.min.js
@@ -427,17 +427,17 @@ onCloseHelpPopup();return false}});if(!i){i=true;var a=$("#mdd_help_location").a
 };this.onToolbarButton=function(a){var b=$(a.target).closest("div.mdd_toolbar_wrap").next(".mdd_editor_wrap").children(
 "textarea").data("mdd");b.InvokeCommand($(a.target).attr("id").substr(4));return false}})();(function(a){a.fn.
 MarkdownDeep=function(f){var h={resizebar:true,toolbar:true,help_location:"mdd_help.html"};if(f)a.extend(h,f);
-return this.each(function(){var d=a(this).parent(".mdd_editor_wrap");if(d.length==0)d=a(this).wrap(
+return this.each(function(l){var d=a(this).parent(".mdd_editor_wrap");if(d.length==0)d=a(this).wrap(
 '<div class="mdd_editor_wrap" />').parent();if(h.toolbar){var k=d.prev(".mdd_toolbar_wrap"),c=d.prev(".mdd_toolbar");if(
 k.length==0){if(c.length==0){c=a('<div class="mdd_toolbar" />');c.insertBefore(d)}k=c.wrap(
 '<div class="mdd_toolbar_wrap" />').parent()}else if(c.length==0){c=a('<div class="mdd_toolbar" />');k.html(c)}c.append(
 a(MarkdownDeepEditorUI.ToolbarHtml()));a("a.mdd_button",c).click(MarkdownDeepEditorUI.onToolbarButton);a("a.mdd_help",c)
-.click(MarkdownDeepEditorUI.onShowHelpPopup);if(!MarkdownDeepEditorUI.HelpHtmlWritten){var l=a(MarkdownDeepEditorUI.
-HelpHtml(h.help_location));l.appendTo(a("body"));a("#mdd_close_help").click(MarkdownDeepEditorUI.onCloseHelpPopup);
+.click(MarkdownDeepEditorUI.onShowHelpPopup);if(!MarkdownDeepEditorUI.HelpHtmlWritten){var m=a(MarkdownDeepEditorUI.
+HelpHtml(h.help_location));m.appendTo(a("body"));a("#mdd_close_help").click(MarkdownDeepEditorUI.onCloseHelpPopup);
 MarkdownDeepEditorUI.HelpHtmlWritten=true}}var b,e;if(h.resizebar){e=d.next(".mdd_resizer_wrap"),b=e.length==0?d.next(
 ".mdd_resizer"):e.children(".mdd_resizer");if(e.length==0){if(b.length==0){b=a('<div class="mdd_resizer" />');b.
 insertAfter(d)}e=b.wrap('<div class="mdd_resizer_wrap" />').parent()}else if(b.length==0){b=a(
 '<div class="mdd_resizer" />');e.html(b)}e.bind("mousedown",MarkdownDeepEditorUI.onResizerMouseDown)}var j=a(this).attr(
-"data-mdd-preview");if(!j)j=".mdd_preview";var i=a(j)[0];if(!i){a('<div class="mdd_preview"></div>').insertAfter(b?b:
-this);i=a(".mdd_preview")[0]}var g=new MarkdownDeepEditor.Editor(this,i);if(f){jQuery.extend(g.Markdown,f);jQuery.extend
+"data-mdd-preview");if(!j)j=".mdd_preview";var i=a(j)[l];if(!i){a('<div class="mdd_preview"></div>').insertAfter(b?b:
+this);i=a(".mdd_preview")[l]}var g=new MarkdownDeepEditor.Editor(this,i);if(f){jQuery.extend(g.Markdown,f);jQuery.extend
 (g,f)}g.onOptionsChanged();a(this).data("mdd",g)})}})(jQuery)


### PR DESCRIPTION
When two or more editors are placed on a page, only one of the corresponding preview sections is refreshed when either of the editors is updated. The editor index is now used so the appropriate preview section is updated. Two new views have also been added to the sample app to demo multiple editors on a page.
