### PR TITLE
exception when parsing annotation

### DIFF
--- a/MarkdownDeep/MardownDeep.cs
+++ b/MarkdownDeep/MardownDeep.cs
@@ -171,19 +171,22 @@ namespace MarkdownDeep
 						string strReturnLink = string.Format("<a href=\"#fnref:{0}\" rev=\"footnote\">&#8617;</a>", (string)fn.data);
 
 						// Get the last child of the footnote
-						var child = fn.children[fn.children.Count - 1];
-						if (child.blockType == BlockType.p)
+						if (fn.children.Count > 0)
 						{
-							child.blockType = BlockType.p_footnote;
-							child.data = strReturnLink;
-						}
-						else
-						{
-							child = CreateBlock();
-							child.contentLen = 0;
-							child.blockType = BlockType.p_footnote;
-							child.data = strReturnLink;
-							fn.children.Add(child);
+							var child = fn.children[fn.children.Count - 1];
+							if (child.blockType == BlockType.p)
+							{
+								child.blockType = BlockType.p_footnote;
+								child.data = strReturnLink;
+							}
+							else
+							{
+								child = CreateBlock();
+								child.contentLen = 0;
+								child.blockType = BlockType.p_footnote;
+								child.data = strReturnLink;
+								fn.children.Add(child);
+							}
 						}
 
 


### PR DESCRIPTION
code

``` csharp
var md = new Markdown( ) { ExtraMode = true };
md.Transform( "[^1]\n[^1]:" );
```

problem at

``` csharp
var child = fn.children[fn.children.Count - 1]; // index is 0 - 1
```
