### PR TITLE
various fixes in server-side Markdown.OnQualifyUrl

### DIFF
--- a/MarkdownDeep/MardownDeep.cs
+++ b/MarkdownDeep/MardownDeep.cs
@@ -336,16 +336,12 @@ namespace MarkdownDeep
 			{
 				var q = QualifyUrl(url);
 				if (q != null)
-					return url;
+					return q;
 			}
 
-			// Quit if we don't have a base location
-			if (String.IsNullOrEmpty(UrlBaseLocation))
+			// Is the url a fragment?
+			if (url.StartsWith("#"))
 				return url;
-
-            // Is the url a fragment?
-            if (url.StartsWith("#"))
-                return url;
 
 			// Is the url already fully qualified?
 			if (Utils.IsUrlFullyQualified(url))
@@ -357,6 +353,10 @@ namespace MarkdownDeep
 				{
 					return UrlRootLocation + url;
 				}
+
+				// Quit if we don't have a base location
+				if (String.IsNullOrEmpty(UrlBaseLocation))
+					return url;
 
 				// Need to find domain root
 				int pos = UrlBaseLocation.IndexOf("://");
@@ -376,6 +376,10 @@ namespace MarkdownDeep
 			}
 			else
 			{
+				// Quit if we don't have a base location
+				if (String.IsNullOrEmpty(UrlBaseLocation))
+					return url;
+
 				if (!UrlBaseLocation.EndsWith("/"))
 					return UrlBaseLocation + "/" + url;
 				else


### PR DESCRIPTION
The logic that was used was different from the JS version; the JS version was more correct as just specifying UrlRootLocation would give proper results but would fail in the server-side version. In
addition, a bug was fixed where the return value of QualifyUrl was being ignored.
