### PR TITLE
Added property AllowUserHtml

### DIFF
--- a/MarkdownDeep/BlockProcessor.cs
+++ b/MarkdownDeep/BlockProcessor.cs
@@ -1050,7 +1050,7 @@ namespace MarkdownDeep
 
 			// Safe mode?
 			bool bHasUnsafeContent = false;
-			if (m_markdown.SafeMode && !openingTag.IsSafe())
+			if ((m_markdown.SafeMode && !openingTag.IsSafe()) || !m_markdown.AllowUserHtml)
 				bHasUnsafeContent = true;
 
 			HtmlTagFlags flags = openingTag.Flags;

--- a/MarkdownDeep/MardownDeep.cs
+++ b/MarkdownDeep/MardownDeep.cs
@@ -43,6 +43,7 @@ namespace MarkdownDeep
 			m_Footnotes = new Dictionary<string, Block>();
 			m_UsedFootnotes = new List<Block>();
 			m_UsedHeaderIDs = new Dictionary<string, bool>();
+			AllowUserHtml = true;
 		}
 
 		internal List<Block> ProcessBlocks(string str)
@@ -234,6 +235,16 @@ namespace MarkdownDeep
 		// markdown syntax within them.  
 		// (Similar to Pandoc's handling of markdown in html)
 		public bool MarkdownInHtml
+		{
+			get;
+			set;
+		}
+
+		/// <summary>
+		/// Gets or sets whether the user can use html tags (like <u>) or whether all tags will be
+		/// quoted.
+		/// </summary>
+		public bool AllowUserHtml
 		{
 			get;
 			set;

--- a/MarkdownDeep/SpanFormatter.cs
+++ b/MarkdownDeep/SpanFormatter.cs
@@ -395,7 +395,7 @@ namespace MarkdownDeep
 						HtmlTag tag = HtmlTag.Parse(this);
 						if (tag != null)
 						{
-							if (!m_Markdown.SafeMode || tag.IsSafe())
+								if ((!m_Markdown.SafeMode || tag.IsSafe()) && m_Markdown.AllowUserHtml)
 							{
 								// Yes, create a token for it
 								token = CreateToken(TokenType.HtmlTag, save, position - save);

--- a/MarkdownDeepJS/MarkdownDeep.js
+++ b/MarkdownDeepJS/MarkdownDeep.js
@@ -59,7 +59,8 @@ var MarkdownDeep = new function () {
         FormatCodeBlockAttributes: null,
         FormatCodeBlock: null,
         ExtractHeadBlocks: false,
-        HeadBlockContent: ""
+        HeadBlockContent: "",
+        AllowUserHtml: true
     };
 
     var p = Markdown.prototype;
@@ -2017,7 +2018,7 @@ var MarkdownDeep = new function () {
                     var tag = ParseHtmlTag(p);
                     if (tag != null) {
                         // Yes, create a token for it
-                        if (!this.m_Markdown.SafeMode || tag.IsSafe()) {
+                        if ((!this.m_Markdown.SafeMode || tag.IsSafe()) && this.m_Markdown.AllowUserHtml) {
                             // Yes, create a token for it
                             token = this.CreateToken(TokenType_HtmlTag, save, p.m_position - save);
                         }
@@ -3760,7 +3761,7 @@ var MarkdownDeep = new function () {
 
         // Safe mode?
         var bHasUnsafeContent = false;
-        if (this.m_Markdown.SafeMode && !openingTag.IsSafe())
+        if ((this.m_Markdown.SafeMode && !openingTag.IsSafe()) || !this.m_Markdown.AllowUserHtml)
             bHasUnsafeContent = true;
 
         var flags = openingTag.get_Flags();

--- a/MarkdownDeepJS/MarkdownDeep.min.js
+++ b/MarkdownDeepJS/MarkdownDeep.min.js
@@ -6,27 +6,27 @@ if(b[c]===e)return c;return-1}function i(){this.bz=new E(this);this.bC=[];this.b
 SafeMode:false,ExtraMode:false,MarkdownInHtml:false,AutoHeadingIDs:false,UrlBaseLocation:null,UrlRootLocation:null,
 NewWindowForExternalLinks:false,NewWindowForLocalLinks:false,NoFollowLinks:false,NoFollowExternalLinks:false,
 HtmlClassFootnotes:"footnotes",HtmlClassTitledImages:null,RenderingTitledImage:false,FormatCodeBlockAttributes:null,
-FormatCodeBlock:null,ExtractHeadBlocks:false,HeadBlockContent:""};var a=i.prototype;function ao(b,c,e,g){return b.slice(
-0,c).concat(g).concat(b.slice(c+e))}i.prototype.GetListItems=function(k,n){var c=this.aE(k),b;for(b=0;b<c.length;b++){
-var e=c[b];if((e.v==23||e.v==15||e.v==22)&&e.C){c=ao(c,b,1,e.C);b--;continue}if(n<e.ay)break}b--;if(b<0)return null;var 
-h=c[b];if(h.v!=21&&h.v!=20)return null;var g=[],m=h.C;for(var j=0;j<m.length;j++)g.push(m[j].ay);b++;if(b<c.length)g.
-push(c[b].ay);else g.push(k.length);return g};i.prototype.Transform=function(c){var n=c.indexOf("\r");if(n>=0){var m=c.
-indexOf("\n");if(m>=0)if(m<n)c=c.replace(/\n\r/g,"\n");else c=c.replace(/\r\n/g,"\n");c=c.replace(/\r/g,"\n")}this.
-HeadBlockContent="";var k=this.aE(c);if(this.bn!=null){var j=[];for(var r in this.bn)j.push(this.bn[r]);j.sort(function(
-p,q){return q.Abbr.length-p.Abbr.length});this.bn=j}var b=this.bF;b.K();for(var g=0;g<k.length;g++){var s=k[g];s.l(this,
-b)}if(this.bI.length>0){b.x('\n<div class="');b.x(this.HtmlClassFootnotes);b.x('">\n');b.x("<hr />\n");b.x("<ol>\n");
-for(var g=0;g<this.bI.length;g++){var h=this.bI[g];b.x('<li id="fn:');b.x(h.X);b.x('">\n');var o='<a href="#fnref:'+h.X+
-'" rev="footnote">&#8617;</a>',e=h.C[h.C.length-1];if(e.v==12){e.v=29;e.X=o}else{e=new B();e.N=0;e.v=29;e.X=o;h.C.push(e
-)}h.l(this,b);b.x("</li>\n")}b.x("</ol>\n");b.x("</div>\n")}return b.bh()};i.prototype.OnQualifyUrl=function(b){if(au(b,
-"#"))return b;if(aj(b))return b;if(au(b,"/")){var e=this.UrlRootLocation;if(!e){if(!this.UrlBaseLocation)return b;var c=
-this.UrlBaseLocation.indexOf("://");if(c==-1)c=0;else c+=3;c=this.UrlBaseLocation.indexOf("/",c);e=c<0?this.
-UrlBaseLocation:this.UrlBaseLocation.substr(0,c)}return e+b}else{if(!this.UrlBaseLocation)return b;if(!T(this.
-UrlBaseLocation,"/"))return this.UrlBaseLocation+"/"+b;else return this.UrlBaseLocation+b}};i.prototype.OnGetImageSize=
-function(b,c){return null};i.prototype.OnPrepareLink=function(b){var c=b.attributes.href;if(this.NoFollowLinks)b.
-attributes.rel="nofollow";if(this.NoFollowExternalLinks)if(aj(c))b.attributes.rel="nofollow";if(this.
-NewWindowForExternalLinks&&aj(c)||this.NewWindowForLocalLinks&&!aj(c))b.attributes.target="_blank";b.attributes.href=
-this.OnQualifyUrl(c)};i.prototype.OnPrepareImage=function(b,e){var c=this.OnGetImageSize(b.attributes.src,e);if(c!=null)
-{b.attributes.width=c.width;b.attributes.height=c.height}b.attributes.src=this.OnQualifyUrl(b.attributes.src)};i.
+FormatCodeBlock:null,ExtractHeadBlocks:false,HeadBlockContent:"",AllowUserHtml:true};var a=i.prototype;function ao(b,c,e
+,g){return b.slice(0,c).concat(g).concat(b.slice(c+e))}i.prototype.GetListItems=function(k,n){var c=this.aE(k),b;for(b=0
+;b<c.length;b++){var e=c[b];if((e.v==23||e.v==15||e.v==22)&&e.C){c=ao(c,b,1,e.C);b--;continue}if(n<e.ay)break}b--;if(b<0
+)return null;var h=c[b];if(h.v!=21&&h.v!=20)return null;var g=[],m=h.C;for(var j=0;j<m.length;j++)g.push(m[j].ay);b++;
+if(b<c.length)g.push(c[b].ay);else g.push(k.length);return g};i.prototype.Transform=function(c){var n=c.indexOf("\r");
+if(n>=0){var m=c.indexOf("\n");if(m>=0)if(m<n)c=c.replace(/\n\r/g,"\n");else c=c.replace(/\r\n/g,"\n");c=c.replace(/\r/g
+,"\n")}this.HeadBlockContent="";var k=this.aE(c);if(this.bn!=null){var j=[];for(var r in this.bn)j.push(this.bn[r]);j.
+sort(function(p,q){return q.Abbr.length-p.Abbr.length});this.bn=j}var b=this.bF;b.K();for(var g=0;g<k.length;g++){var s=
+k[g];s.l(this,b)}if(this.bI.length>0){b.x('\n<div class="');b.x(this.HtmlClassFootnotes);b.x('">\n');b.x("<hr />\n");b.x
+("<ol>\n");for(var g=0;g<this.bI.length;g++){var h=this.bI[g];b.x('<li id="fn:');b.x(h.X);b.x('">\n');var o=
+'<a href="#fnref:'+h.X+'" rev="footnote">&#8617;</a>',e=h.C[h.C.length-1];if(e.v==12){e.v=29;e.X=o}else{e=new B();e.N=0;
+e.v=29;e.X=o;h.C.push(e)}h.l(this,b);b.x("</li>\n")}b.x("</ol>\n");b.x("</div>\n")}return b.bh()};i.prototype.
+OnQualifyUrl=function(b){if(au(b,"#"))return b;if(aj(b))return b;if(au(b,"/")){var e=this.UrlRootLocation;if(!e){if(!
+this.UrlBaseLocation)return b;var c=this.UrlBaseLocation.indexOf("://");if(c==-1)c=0;else c+=3;c=this.UrlBaseLocation.
+indexOf("/",c);e=c<0?this.UrlBaseLocation:this.UrlBaseLocation.substr(0,c)}return e+b}else{if(!this.UrlBaseLocation)
+return b;if(!T(this.UrlBaseLocation,"/"))return this.UrlBaseLocation+"/"+b;else return this.UrlBaseLocation+b}};i.
+prototype.OnGetImageSize=function(b,c){return null};i.prototype.OnPrepareLink=function(b){var c=b.attributes.href;if(
+this.NoFollowLinks)b.attributes.rel="nofollow";if(this.NoFollowExternalLinks)if(aj(c))b.attributes.rel="nofollow";if(
+this.NewWindowForExternalLinks&&aj(c)||this.NewWindowForLocalLinks&&!aj(c))b.attributes.target="_blank";b.attributes.
+href=this.OnQualifyUrl(c)};i.prototype.OnPrepareImage=function(b,e){var c=this.OnGetImageSize(b.attributes.src,e);if(c!=
+null){b.attributes.width=c.width;b.attributes.height=c.height}b.attributes.src=this.OnQualifyUrl(b.attributes.src)};i.
 prototype.GetLinkDefinition=function(b){if(this.bv.hasOwnProperty(b))return this.bv[b];else return null};a.aE=function(b
 ){this.bv=[];this.bs=[];this.bI=[];this.bJ=[];this.bn=null;return new D(this,this.MarkdownInHtml).aH(b)};a.A=function(b)
 {this.bv[b.id]=b};a.z=function(b){this.bs[b.X]=b};a.Q=function(c){var b=this.bs[c];if(b!=undefined){this.bI.push(b);
@@ -150,149 +150,149 @@ b.x("<abbr");if(e.Title){b.x(' title="');b.au(e.Title,0,e.Title.length);b.x('"')
 this.bw.am(),o=k==null?/[\*\_\`\[\!\<\&\ \\]/g:null,q=this.bw.ExtraMode,g=b.by;while(!b.J()){if(o!=null&&!b.aa(o))break;
 var m=b.by,c=null;switch(b.H()){case"*":case"_":c=this.P();if(c!=null)switch(c.type){case 13:case 11:case 12:if(h==null)
 h=[];h.push(c);break}break;case"`":c=this.aF();break;case"[":case"!":var t=b.by;c=this.aI();if(c==null)b.by=t;break;case
-"<":var e=b.by,p=ag(b);if(p!=null)if(!this.bw.SafeMode||p.at())c=this.U(1,e,b.by-e);else b.by=e;else{b.by=e;c=this.aD();
-if(c==null)b.by=e}break;case"&":var e=b.by;if(b.a6())c=this.U(2,e,b.by-e);break;case" ":if(b.F(1)==" "&&Y(b.F(2))){b.a5(
-2);if(!b.J()){b.aZ();c=this.U(8,m,0)}}break;case"\\":if(U(b.F(1),q)){c=this.U(0,b.by+1,1);b.a5(2)}break}if(c==null&&k!=
-null&&!R(b.F(-1))){var v=b.by;for(var r in k){var n=k[r];if(b.a9(n.Abbr)&&!R(b.H())){c=this.O(15,n);break}b.bK=v}}if(c!=
-null){if(m>g)j.push(this.U(0,g,m-g));j.push(c);g=b.by}else b.a5(1)}if(b.by>g)j.push(this.U(0,g,b.by-g));if(h!=null)this.
-aV(j,h)};a.P=function(){var b=this.bB,e=b.H(),k=e=="*"?"_":"*",c=b.by;if(b.D()||ad(b.F(-1))){while(ae(b.H()))b.a5(1);if(
-b.J()||ad(b.H()))return this.U(2,c,b.by-c);b.by=c}while(ae(b.F(-1)))b.a5(-1);var h=b.D()||ad(b.F(-1));b.by=c;while(b.H()
-==e)b.a5(1);var j=b.by-c;while(ae(b.F(1)))b.a5(1);var g=b.J()||ad(b.H());b.by=c+j;if(h)return this.U(11,c,b.by-c);if(g)
-return this.U(12,c,b.by-c);if(this.bw.ExtraMode&&e=="_"&&R(b.H()))return null;return this.U(13,c,b.by-c)};a.bg=function(
-h,g,b,c){var e=this.U(b.type,b.startOffset+c,b.length-c);b.length=c;g.splice(S(g,b)+1,0,e);h.splice(S(h,b)+1,0,e);
-return e};a.aV=function(n,b){var m=this.bB.E,j=true;while(j){j=false;for(var h=0;h<b.length;h++){var c=b[h];if(c.type!=
-11&&c.type!=13)continue;for(var k=h+1;k<b.length;k++){var g=b[k];if(g.type!=12&&g.type!=13)break;if(m.charAt(c.
-startOffset)!=m.charAt(g.startOffset))continue;var e=Math.min(c.length,g.length);if(e>=3)e=e%2==1?1:2;if(c.length>e){c=
-this.bg(n,b,c,c.length-e);h--}if(g.length>e)this.bg(n,b,g,e);c.type=e==1?3:5;g.type=e==1?4:6;b.splice(S(b,c),1);b.splice
-(S(b,g),1);j=true;break}}}};a.aD=function(){if(this.br)return null;var c=this.bB;c.a5(1);c.az();var j=this.bw.ExtraMode;
-while(!c.J()){var h=c.H();if(ad(h))break;if(h==">"){var b=az(c.W(),j),e=null;if(ah(b)){var g;if(b.toLowerCase().substr(0
-,7)=="mailto:")g=b.substr(7);else{g=b;b="mailto:"+b}e=new am(new C("auto",b,null),g)}else if(al(b))e=new am(new C("auto"
-,b,null),b);if(e!=null){c.a5(1);return this.O(9,e)}return null}c.a2(j)}return null};a.aI=function(){var b=this.bB,h=b.aW
-("!")?10:9;if(!b.aW("["))return null;var o=this.by;if(this.bw.ExtraMode&&h==9&&b.aW("^")){b.a8();b.az();var m=b.a4();if(
-m!=null&&b.aW("]")){var s=this.bw.Q(m);if(s>=0)return this.O(14,{index:s,id:m})}this.by=o}if(this.br&&h==9)return null;
-var r=this.bw.ExtraMode;b.az();var j=1;while(!b.J()){var p=b.H();if(p=="[")j++;else if(p=="]"){j--;if(j==0)break}b.a2(r)
-}if(b.J())return null;var n=az(b.W(),r);b.a5(1);o=b.by;if(b.aW("(")){var t=ar(b,null,this.bw.ExtraMode);if(t==null)
-return null;b.bd();if(!b.aW(")"))return null;return this.O(h,new am(t,n))}if(!b.aW(" "))b.aW("\t");if(b.Y()){b.aZ();b.a8
-()}var c=null;if(b.H()=="["){b.a5(1);b.az();if(!b.Z("]"))return null;c=b.W();b.a5(1)}else b.by=o;if(!c){c=n;while(true){
-var k=c.indexOf("\n");if(k<0)break;var g=k;while(g>0&&ad(c.charAt(g-1)))g--;var e=k;while(e<c.length&&ad(c.charAt(e)))
-e++;c=c.substr(0,g)+" "+c.substr(e)}}var q=this.bw.GetLinkDefinition(c);if(q==null)return null;return this.O(h,new am(q,
-n))};a.aF=function(){var b=this.bB,c=b.by,e=0;while(b.aW("`"))e++;b.bd();if(b.J())return this.U(0,c,b.by-c);var g=b.by;
-if(!b.Z(b.E.substr(c,e)))return this.U(0,c,b.by-c);var h=b.by+e;while(ad(b.F(-1)))b.a5(-1);var j=this.U(7,g,b.by-g);b.by
-=h;return j};a.U=function(g,e,c){if(this.bG.length!=0){var b=this.bG.pop();b.type=g;b.startOffset=e;b.length=c;b.X=null;
-return b}else return new ax(g,e,c)};a.O=function(e,c){if(this.bG.length!=0){var b=this.bG.pop();b.type=e;b.X=c;return b}
-else{var b=new ax(e,0,0);b.X=c;return b}};a.ak=function(b){b.X=null;this.bG.push(b)};function B(){}a=B.prototype;a.E=
-null;a.v=0;a.R=0;a.N=0;a.ay=0;a.aA=0;a.C=null;a.X=null;a.an=function(){if(this.E==null)return null;if(this.R==-1)
-return this.E;return this.E.substr(this.R,this.N)};a.al=function(){var c=new F();for(var b=0;b<this.C.length;b++){c.x(
-this.C[b].an());c.x("\n")}return c.bh()};a.aN=function(e,c){for(var b=0;b<this.C.length;b++)this.C[b].l(e,c)};a.aX=
-function(e){if(typeof this.X=="string")return this.X;var c=at(this.E,this.R,this.ao()),b=null;if(c!=null){this.a3(c.end)
-;b=c.id}else b=e.aC(this.E,this.R,this.N);this.X=b;return b};a.l=function(c,b){switch(this.v){case 0:return;case 12:c.bz
-.ah(b,this.E,this.R,this.N);break;case 17:c.bz.ae(b,this.E,this.R,this.N);b.x("\n");break;case 1:case 2:case 3:case 4:
-case 5:case 6:if(c.ExtraMode&&!c.SafeMode){b.x("<h"+(this.v-1+1).toString());var k=this.aX(c);if(k){b.x(' id="');b.x(k);
-b.x('">')}else b.x(">")}else b.x("<h"+(this.v-1+1).toString()+">");c.bz.ae(b,this.E,this.R,this.N);b.x("</h"+(this.v-1+1
-).toString()+">\n");break;case 14:b.x("<hr />\n");return;case 10:case 11:b.x("<li>");c.bz.ae(b,this.E,this.R,this.N);b.x
-("</li>\n");break;case 15:b.x(this.E.substr(this.R,this.N));return;case 16:b.au(this.E,this.R,this.N);return;case 18:b.x
-("<pre");if(c.FormatCodeBlockAttributes!=null)b.x(c.FormatCodeBlockAttributes(this.X));b.x("><code>");var h=b;if(c.
-FormatCodeBlock){h=b;b=new F()}for(var e=0;e<this.C.length;e++){var j=this.C[e];b.av(j.E,j.R,j.N);b.x("\n")}if(c.
-FormatCodeBlock){h.x(c.FormatCodeBlock(b.bh(),this.X));b=h}b.x("</code></pre>\n\n");return;case 9:b.x("<blockquote>\n");
-this.aN(c,b);b.x("</blockquote>\n");return;case 19:b.x("<li>\n");this.aN(c,b);b.x("</li>\n");return;case 20:b.x("<ol>\n"
-);this.aN(c,b);b.x("</ol>\n");return;case 21:b.x("<ul>\n");this.aN(c,b);b.x("</ul>\n");return;case 22:var g=this.X,n=g.
-name.toLowerCase();if(n=="a")c.OnPrepareLink(g);else if(n=="img")c.OnPrepareImage(g,c.RenderingTitledImage);g.aS(b);b.x(
-"\n");this.aN(c,b);g.aO(b);b.x("\n");return;case 23:case 28:this.aN(c,b);return;case 24:this.X.l(c,b);return;case 25:b.x
-("<dd>");if(this.C!=null){b.x("\n");this.aN(c,b)}else c.bz.ae(b,this.E,this.R,this.N);b.x("</dd>\n");break;case 26:if(
-this.C==null){var m=this.an().split("\n");for(var e=0;e<m.length;e++){var o=m[e];b.x("<dt>");c.bz.af(b,ay(o));b.x(
-"</dt>\n")}}else{b.x("<dt>\n");this.aN(c,b);b.x("</dt>\n")}break;case 27:b.x("<dl>\n");this.aN(c,b);b.x("</dl>\n");
-return;case 29:b.x("<p>");if(this.N>0){c.bz.ae(b,this.E,this.R,this.N);b.x("&nbsp;")}b.x(this.X);b.x("</p>\n");break}};a
-.aY=function(){this.v=12;this.R=this.ay;this.N=this.aA};a.ao=function(){return this.R+this.N};a.a3=function(b){this.N=b-
-this.R};a.aq=function(){var c=0;for(var b=this.ay;b<this.ay+this.aA;b++)if(this.E.charAt(b)==" ")c++;else break;return c
-};a.V=function(b){this.v=b.v;this.E=b.E;this.R=b.R;this.N=b.N;this.ay=b.ay;this.aA=b.aA;return this};function D(b,c){
-this.bw=b;this.bx=0;this.bo=c}a=D.prototype;a.aH=function(c){var b=new G(c);return this.a1(b)};a.aL=function(g,e,b){var 
-c=new G(g,e,b);return this.a1(c)};a.bi=function(b,c,e){if(e.length>1)return false;if(e.length==1){var g=b.by;b.by=e[0].
-ay;c.bu=c.aG(b);if(c.bu==null)return false;b.by=g;e.length=0}while(true){var g=b.by,h=c.aG(b);if(h!=null){c.bA.push(h);
-continue}b.by=g;break}return true};a.a1=function(j){var e=[],c=[],k=-1;while(!j.J()){var m=k==0,b=this.ab(j);k=b.v;if(b.
-v==25)b.X=m;if(b.v==7||b.v==8){if(c.length>0){var g=c.pop();this.S(e,c);if(g.v!=0){g.aY();g.v=b.v==7?1:2;e.push(g);
-continue}}if(b.v==7){b.aY();c.push(b)}else if(b.N>=3){b.v=14;e.push(b)}else{b.aY();c.push(b)}continue}var h=c.length>0?c
-[0].v:0;if(b.v==24){var o=b.X,n=j.by;if(!this.bi(j,o,c)){j.by=n;b.aY()}else{e.push(b);continue}}switch(b.v){case 0:
-switch(h){case 0:this.ai(b);break;case 12:this.S(e,c);this.ai(b);break;case 9:case 10:case 11:case 25:case 28:case 13:c.
-push(b);break}break;case 12:switch(h){case 0:case 12:c.push(b);break;case 9:case 10:case 11:case 25:case 28:var g=c[c.
-length-1];if(g.v==0){this.S(e,c);c.push(b)}else c.push(b);break;case 13:this.S(e,c);c.push(b);break}break;case 13:
-switch(h){case 0:c.push(b);break;case 12:case 9:var g=c[c.length-1];if(g.v==0){this.S(e,c);c.push(b)}else{b.aY();c.push(
-b)}break;case 10:case 11:case 13:case 25:case 28:c.push(b);break}break;case 9:if(h!=9)this.S(e,c);c.push(b);break;case 
-10:case 11:switch(h){case 0:c.push(b);break;case 12:case 9:var g=c[c.length-1];if(g.v==0||this.bx==10||this.bx==11||this
-.bx==25){this.S(e,c);c.push(b)}else{b.aY();c.push(b)}break;case 10:case 11:if(b.v!=10&&b.v!=11)this.S(e,c);c.push(b);
-break;case 25:case 28:if(b.v!=h)this.S(e,c);c.push(b);break;case 13:this.S(e,c);c.push(b);break}break;case 25:case 28:
-switch(h){case 0:case 12:case 25:case 28:this.S(e,c);c.push(b);break;default:b.aY();c.push(b);break}break;default:this.S
-(e,c);e.push(b);break}}this.S(e,c);if(this.bw.ExtraMode)this.I(e);return e};a.T=function(c){var b;if(this.bw.bC.length>1
-)b=this.bw.bC.pop();else b=new B();b.ay=c;return b};a.ai=function(b){this.bw.bC.push(b)};a.aj=function(b){for(var c=0;c<
-b.length;c++)this.bw.bC.push(b[c]);b.length=0};a.aQ=function(g){var b=this.bw.as();for(var c=0;c<g.length;c++){var e=g[c
-];b.x(e.E.substr(e.R,e.N));b.x("\n")}return b.bh()};a.S=function(c,b){while(b.length>0&&b[b.length-1].v==0)this.ai(b.pop
-());if(b.length==0)return;switch(b[0].v){case 12:var h=this.T(b[0].ay);h.v=12;h.E=b[0].E;h.R=b[0].R;h.a3(b[b.length-1].
-ao());c.push(h);this.aj(b);break;case 9:var p=this.aQ(b),o=new D(this.bw,this.bo);o.bx=9;var n=this.T(b[0].ay);n.v=9;n.C
-=o.aH(p);this.aj(b);c.push(n);break;case 10:case 11:c.push(this.M(b));break;case 25:if(c.length>0){var j=c[c.length-1];
-switch(j.v){case 12:j.v=26;break;case 25:break;default:var k=this.T(j.ay);k.v=26;k.C=[];k.C.push(j);c.pop();c.push(k);
-break}}c.push(this.G(b));break;case 28:this.bw.z(this.L(b));break;case 13:var e=this.T(b[0].ay);e.v=18;e.C=[];var g=b[0]
-.an();if(g.substr(0,2)=="{{"&&g.substr(g.length-2,2)=="}}"){e.X=g.substr(2,g.length-4);b.splice(0,1)}for(var m=0;m<b.
-length;m++)e.C.push(b[m]);c.push(e);b.length=0;break}};a.ab=function(c){var b=this.T(c.by);b.E=c.E;b.R=c.by;b.N=-1;b.v=
-this.ac(c,b);if(b.N<0){c.bb();b.N=c.by-b.R}b.aA=c.by-b.ay;c.aZ();return b};a.ac=function(b,c){if(b.Y())return 0;var h=b.
-by,e=b.H();if(e=="#"){var j=1;b.a5(1);while(b.H()=="#"){j++;b.a5(1)}if(j>6)j=6;b.a8();c.R=b.by;b.bb();if(this.bw.
-ExtraMode&&!this.bw.SafeMode){var m=at(b.E,c.R,b.by);if(m!=null){c.X=m.id;b.by=m.end}}while(b.by>c.R&&b.F(-1)=="#")b.a5(
--1);while(b.by>c.R&&ad(b.F(-1)))b.a5(-1);c.N=b.by-c.R;b.bb();return 1+j-1}if(e=="-"||e=="="){var k=e;while(b.H()==k)b.a5
-(1);b.a8();if(b.Y())return k=="="?7:8;b.by=h}if(this.bw.ExtraMode){var s=av(b);if(s!=null){c.X=s;return 24}b.by=h;if(e==
-"~"||e=="`"){if(this.aJ(b,c))return c.v;b.by=h}}var g=-1,r=0;while(!b.Y()){if(b.H()==" "){if(g<0)r++}else if(b.H()=="\t"
-){if(g<0)g=b.by}else break;b.a5(1)}if(b.Y()){c.N=0;return 0}if(r>=4){c.R=h+4;return 13}if(g>=0&&g-h<4){c.R=g+1;return 13
-}c.R=b.by;e=b.H();if(e=="<"){if(this.a0(b,c))return c.v;b.by=c.R}if(e==">"){if(ab(b.F(1))){b.a5(2);c.R=b.by;return 9}b.
-a5(1);c.R=b.by;return 9}if(e=="-"||e=="_"||e=="*"){var o=0;while(!b.Y()){var k=b.H();if(b.H()==e){o++;b.a5(1);continue}
-if(ab(b.H())){b.a5(1);continue}break}if(b.Y()&&o>=3)return 14;b.by=c.R}if(this.bw.ExtraMode&&e=="*"&&b.F(1)=="["){b.a5(2
-);b.a8();b.az();while(!b.Y()&&b.H()!="]")b.a5(1);var n=ay(b.W());if(b.H()=="]"&&b.F(1)==":"&&n){b.a5(2);b.a8();b.az();b.
-bb();var v=b.W();this.bw.y(n,v);return 0}b.by=c.R}if((e=="*"||e=="+"||e=="-")&&ab(b.F(1))){b.a5(1);b.a8();c.R=b.by;
-return 11}if(e==":"&&this.bw.ExtraMode&&ab(b.F(1))){b.a5(1);b.a8();c.R=b.by;return 25}if(X(e)){b.a5(1);while(X(b.H()))b.
-a5(1);if(b.aW(".")&&b.a8()){c.R=b.by;return 10}b.by=c.R}if(e=="["){if(this.bw.ExtraMode&&b.F(1)=="^"){var t=b.by;b.a5(2)
-;var p=b.a4();if(p!=null&&b.aW("]")&&b.aW(":")){b.a8();c.R=b.by;c.X=p;return 28}b.by=t}var q=an(b,this.bw.ExtraMode);if(
-q!=null){this.bw.A(q);return 0}}return 12};a.ar=function(c){var b=c.attributes.markdown;if(b==undefined)if(this.bo)
-return 3;else return 0;delete c.attributes.markdown;if(b=="1")return(c.ap()&8)!=0?2:1;if(b=="block")return 1;if(b==
-"deep")return 3;if(b=="span")return 2;return 4};a.aK=function(b,e,o,m){var g=b.by,k=1,j=false;while(!b.J()){if(!b.Z("<")
-)break;var n=b.by,h=ag(b);if(h==null){b.a5(1);continue}if(this.bw.SafeMode&&m==4&&!j)if(!h.at())j=true;if(h.closed)
-continue;if(h.name==o.name)if(h.closing){k--;if(k==0){b.a8();b.aZ();e.v=22;e.X=o;e.a3(b.by);switch(m){case 2:var c=this.
-T(g);c.E=b.E;c.v=17;c.R=g;c.N=n-g;e.C=[];e.C.push(c);break;case 1:case 3:var p=new D(this.bw,m==3);e.C=p.aL(b.E,g,n-g);
-break;case 4:if(j){e.v=16;e.a3(b.by)}else{var c=this.T(g);c.E=b.E;c.v=15;c.R=g;c.N=n-g;e.C=[];e.C.push(c)}break}
-return true}}else k++}return false};a.a0=function(b,c){var g=b.by,h=ag(b);if(h==null)return false;if(h.closing)
-return false;var m=false;if(this.bw.SafeMode&&!h.at())m=true;var q=h.ap();if((q&1)==0)return false;if((q&4)!=0||h.closed
-){b.a8();b.aZ();c.N=b.by-c.R;c.v=m?16:15;return true}if((q&2)!=0){b.a8();if(!b.Y())return false}var o=this.bw.
-ExtractHeadBlocks&&h.name.toLowerCase()=="head",t=b.by;if(!o&&this.bw.ExtraMode){var n=this.ar(h);if(n!=0)return this.aK
-(b,c,h,n)}var k=null,p=1;while(!b.J()){if(!b.Z("<"))break;var s=b.by,j=ag(b);if(j==null){b.a5(1);continue}if(this.bw.
-SafeMode&&!j.at())m=true;if(j.closed)continue;if(!o&&!j.closing&&this.bw.ExtraMode&&!m){var n=this.ar(j);if(n!=0){var r=
-this.T(g);if(this.aK(b,r,j,n)){if(k==null)k=[];if(s>g){var e=this.T(g);e.E=b.E;e.v=15;e.R=g;e.N=s-g;k.push(e)}k.push(r);
-g=b.by;continue}else this.ai(r)}}if(j.name==h.name&&!j.closed)if(j.closing){p--;if(p==0){b.a8();b.aZ();if(m){c.v=16;c.a3
-(b.by);return true}if(k!=null){if(b.by>g){var e=this.T(g);e.E=b.E;e.v=15;e.R=g;e.N=b.by-g;k.push(e)}c.v=23;c.a3(b.by);c.
-C=k;return true}if(o){var v=b.E.substr(t,s-t);this.bw.HeadBlockContent=this.bw.HeadBlockContent+ay(v)+"\n";c.v=15;c.R=b.
-bK;c.contentEnd=b.bK;c.ay=b.bK;return true}c.v=15;c.N=b.by-c.R;return true}}else p++}return 0};a.M=function(b){var r=b[0
-].v,t=b[0].aq();for(var c=1;c<b.length;c++){if(b[c].v==12&&(b[c-1].v==12||b[c-1].v==11||b[c-1].v==10)){b[c-1].a3(b[c].ao
-());this.ai(b[c]);b.splice(c,1);c--;continue}if(b[c].v!=13&&b[c].v!=0){var s=b[c].aq();if(s>t){b[c].v=13;var v=b[c].ao()
-;b[c].R=b[c].ay+s;b[c].a3(v)}}}var h=this.T(0);h.v=r==11?21:20;h.C=[];for(var c=0;c<b.length;c++){var k=c;while(k>0&&b[k
--1].v==0)k--;var g=c;while(g<b.length-1&&b[g+1].v!=11&&b[g+1].v!=10)g++;if(k==g)h.C.push(this.T().V(b[c]));else{var o=
-false,n=this.bw.as();for(var e=k;e<=g;e++){var m=b[e];n.x(m.E.substr(m.R,m.N));n.x("\n");if(b[e].v==0)o=true}var j=this.
-T();j.v=19;j.ay=b[k].ay;var p=new D(this.bw);p.bx=r;j.C=p.aH(n.bh());if(!o)for(var e=0;e<j.C.length;e++){var q=j.C[e];
-if(q.v==12)q.v=17}h.C.push(j)}c=g}h.ay=h.C[0].ay;this.aj(b);b.length=0;return h};a.G=function(b){for(var c=1;c<b.length;
-c++)if(b[c].v==12&&(b[c-1].v==12||b[c-1].v==25)){b[c-1].a3(b[c].ao());this.ai(b[c]);b.splice(c,1);c--;continue}var k=b[0
-].X;if(b.length==1&&!k){var m=b[0];b.length=0;return m}var h=this.bw.as();for(var c=0;c<b.length;c++){var g=b[c];h.x(g.E
-.substr(g.R,g.N));h.x("\n")}var e=this.T(b[0].ay);e.v=25;var j=new D(this.bw);j.bx=25;e.C=j.aH(h.bh());this.aj(b);b.
-length=0;return e};a.I=function(e){var c=null;for(var b=0;b<e.length;b++)switch(e[b].v){case 26:case 25:if(c==null){c=
-this.T(e[b].ay);c.v=27;c.C=[];e.splice(b,0,c);b++}c.C.push(e[b]);e.splice(b,1);b--;break;default:c=null;break}};a.L=
-function(c){for(var b=1;b<c.length;b++)if(c[b].v==12&&(c[b-1].v==12||c[b-1].v==28)){c[b-1].a3(c[b].ao());this.ai(c[b]);c
-.splice(b,1);b--;continue}var h=this.bw.as();for(var b=0;b<c.length;b++){var g=c[b];h.x(g.E.substr(g.R,g.N));h.x("\n")}
-var j=new D(this.bw);j.bx=28;var e=this.T(c[0].ay);e.v=28;e.X=c[0].X;e.C=j.aH(h.bh());this.aj(c);c.length=0;return e};a.
-aJ=function(b,e){var m=b.by,k=b.H();b.az();while(b.H()==k)b.a5(1);var g=b.W();if(g.length<3)return false;b.a8();if(!b.Y(
-))return false;b.aZ();var j=b.by;if(!b.Z(g))return false;if(!Y(b.F(-1)))return false;var h=b.by;b.a5(g.length);b.a8();
-if(!b.Y())return false;e.v=18;e.C=[];h--;var c=this.T(m);c.v=13;c.E=b.E;c.R=j;c.N=h-j;e.C.push(c);return true};function 
-H(){this.bp=[];this.bu=null;this.bA=[]}a=H.prototype;a.ax=false;a.bk=false;a.aG=function(b){b.a8();if(b.Y())return null;
-var e=this.ax;if(this.ax&&!b.aW("|")){e=true;return null}var c=[];while(!b.Y()){b.az();while(!b.Y()&&b.H()!="|")b.a2(
-true);c.push(ay(b.W()));e|=b.aW("|")}if(!e)return null;while(c.length<this.bp.length)c.push("&nbsp;");b.aZ();return c};a
-.aT=function(h,b,e,g){for(var c=0;c<e.length;c++){b.x("\t<");b.x(g);if(c<this.bp.length)switch(this.bp[c]){case 1:b.x(
-' align="left"');break;case 2:b.x(' align="right"');break;case 3:b.x(' align="center"');break}b.x(">");h.bz.af(b,e[c]);b
-.x("</");b.x(g);b.x(">\n")}};a.l=function(e,b){b.x("<table>\n");if(this.bu!=null){b.x("<thead>\n<tr>\n");this.aT(e,b,
-this.bu,"th");b.x("</tr>\n</thead>\n")}b.x("<tbody>\n");for(var c=0;c<this.bA.length;c++){var g=this.bA[c];b.x("<tr>\n")
-;this.aT(e,b,g,"td");b.x("</tr>\n")}b.x("</tbody>\n");b.x("</table>\n")};function av(b){b.a8();if(b.H()!="|"&&b.H()!=":"
-&&b.H()!="-")return null;var c=null;if(b.aW("|")){c=new H();c.ax=true}while(true){b.a8();if(b.H()=="|")return null;var g
-=b.aW(":");while(b.H()=="-")b.a5(1);var h=b.aW(":");b.a8();var e=0;if(g&&h)e=3;else if(g)e=1;else if(h)e=2;if(b.Y()){if(
-c==null)return null;c.bp.push(e);return c}if(!b.aW("|"))return null;if(c==null)c=new H();c.bp.push(e);b.a8();if(b.Y()){c
-.bk=true;return c}}}this.Markdown=i;this.HtmlTag=w})();if(typeof exports!=="undefined")exports.Markdown=MarkdownDeep.
-Markdown
+"<":var e=b.by,p=ag(b);if(p!=null)if((!this.bw.SafeMode||p.at())&&this.bw.AllowUserHtml)c=this.U(1,e,b.by-e);else b.by=e
+;else{b.by=e;c=this.aD();if(c==null)b.by=e}break;case"&":var e=b.by;if(b.a6())c=this.U(2,e,b.by-e);break;case" ":if(b.F(
+1)==" "&&Y(b.F(2))){b.a5(2);if(!b.J()){b.aZ();c=this.U(8,m,0)}}break;case"\\":if(U(b.F(1),q)){c=this.U(0,b.by+1,1);b.a5(
+2)}break}if(c==null&&k!=null&&!R(b.F(-1))){var v=b.by;for(var r in k){var n=k[r];if(b.a9(n.Abbr)&&!R(b.H())){c=this.O(15
+,n);break}b.bK=v}}if(c!=null){if(m>g)j.push(this.U(0,g,m-g));j.push(c);g=b.by}else b.a5(1)}if(b.by>g)j.push(this.U(0,g,b
+.by-g));if(h!=null)this.aV(j,h)};a.P=function(){var b=this.bB,e=b.H(),k=e=="*"?"_":"*",c=b.by;if(b.D()||ad(b.F(-1))){
+while(ae(b.H()))b.a5(1);if(b.J()||ad(b.H()))return this.U(2,c,b.by-c);b.by=c}while(ae(b.F(-1)))b.a5(-1);var h=b.D()||ad(
+b.F(-1));b.by=c;while(b.H()==e)b.a5(1);var j=b.by-c;while(ae(b.F(1)))b.a5(1);var g=b.J()||ad(b.H());b.by=c+j;if(h)
+return this.U(11,c,b.by-c);if(g)return this.U(12,c,b.by-c);if(this.bw.ExtraMode&&e=="_"&&R(b.H()))return null;
+return this.U(13,c,b.by-c)};a.bg=function(h,g,b,c){var e=this.U(b.type,b.startOffset+c,b.length-c);b.length=c;g.splice(S
+(g,b)+1,0,e);h.splice(S(h,b)+1,0,e);return e};a.aV=function(n,b){var m=this.bB.E,j=true;while(j){j=false;for(var h=0;h<b
+.length;h++){var c=b[h];if(c.type!=11&&c.type!=13)continue;for(var k=h+1;k<b.length;k++){var g=b[k];if(g.type!=12&&g.
+type!=13)break;if(m.charAt(c.startOffset)!=m.charAt(g.startOffset))continue;var e=Math.min(c.length,g.length);if(e>=3)e=
+e%2==1?1:2;if(c.length>e){c=this.bg(n,b,c,c.length-e);h--}if(g.length>e)this.bg(n,b,g,e);c.type=e==1?3:5;g.type=e==1?4:6
+;b.splice(S(b,c),1);b.splice(S(b,g),1);j=true;break}}}};a.aD=function(){if(this.br)return null;var c=this.bB;c.a5(1);c.
+az();var j=this.bw.ExtraMode;while(!c.J()){var h=c.H();if(ad(h))break;if(h==">"){var b=az(c.W(),j),e=null;if(ah(b)){var 
+g;if(b.toLowerCase().substr(0,7)=="mailto:")g=b.substr(7);else{g=b;b="mailto:"+b}e=new am(new C("auto",b,null),g)}else 
+if(al(b))e=new am(new C("auto",b,null),b);if(e!=null){c.a5(1);return this.O(9,e)}return null}c.a2(j)}return null};a.aI=
+function(){var b=this.bB,h=b.aW("!")?10:9;if(!b.aW("["))return null;var o=this.by;if(this.bw.ExtraMode&&h==9&&b.aW("^"))
+{b.a8();b.az();var m=b.a4();if(m!=null&&b.aW("]")){var s=this.bw.Q(m);if(s>=0)return this.O(14,{index:s,id:m})}this.by=o
+}if(this.br&&h==9)return null;var r=this.bw.ExtraMode;b.az();var j=1;while(!b.J()){var p=b.H();if(p=="[")j++;else if(p==
+"]"){j--;if(j==0)break}b.a2(r)}if(b.J())return null;var n=az(b.W(),r);b.a5(1);o=b.by;if(b.aW("(")){var t=ar(b,null,this.
+bw.ExtraMode);if(t==null)return null;b.bd();if(!b.aW(")"))return null;return this.O(h,new am(t,n))}if(!b.aW(" "))b.aW(
+"\t");if(b.Y()){b.aZ();b.a8()}var c=null;if(b.H()=="["){b.a5(1);b.az();if(!b.Z("]"))return null;c=b.W();b.a5(1)}else b.
+by=o;if(!c){c=n;while(true){var k=c.indexOf("\n");if(k<0)break;var g=k;while(g>0&&ad(c.charAt(g-1)))g--;var e=k;while(e<
+c.length&&ad(c.charAt(e)))e++;c=c.substr(0,g)+" "+c.substr(e)}}var q=this.bw.GetLinkDefinition(c);if(q==null)return null
+;return this.O(h,new am(q,n))};a.aF=function(){var b=this.bB,c=b.by,e=0;while(b.aW("`"))e++;b.bd();if(b.J())return this.
+U(0,c,b.by-c);var g=b.by;if(!b.Z(b.E.substr(c,e)))return this.U(0,c,b.by-c);var h=b.by+e;while(ad(b.F(-1)))b.a5(-1);var 
+j=this.U(7,g,b.by-g);b.by=h;return j};a.U=function(g,e,c){if(this.bG.length!=0){var b=this.bG.pop();b.type=g;b.
+startOffset=e;b.length=c;b.X=null;return b}else return new ax(g,e,c)};a.O=function(e,c){if(this.bG.length!=0){var b=this
+.bG.pop();b.type=e;b.X=c;return b}else{var b=new ax(e,0,0);b.X=c;return b}};a.ak=function(b){b.X=null;this.bG.push(b)};
+function B(){}a=B.prototype;a.E=null;a.v=0;a.R=0;a.N=0;a.ay=0;a.aA=0;a.C=null;a.X=null;a.an=function(){if(this.E==null)
+return null;if(this.R==-1)return this.E;return this.E.substr(this.R,this.N)};a.al=function(){var c=new F();for(var b=0;b
+<this.C.length;b++){c.x(this.C[b].an());c.x("\n")}return c.bh()};a.aN=function(e,c){for(var b=0;b<this.C.length;b++)this
+.C[b].l(e,c)};a.aX=function(e){if(typeof this.X=="string")return this.X;var c=at(this.E,this.R,this.ao()),b=null;if(c!=
+null){this.a3(c.end);b=c.id}else b=e.aC(this.E,this.R,this.N);this.X=b;return b};a.l=function(c,b){switch(this.v){case 0
+:return;case 12:c.bz.ah(b,this.E,this.R,this.N);break;case 17:c.bz.ae(b,this.E,this.R,this.N);b.x("\n");break;case 1:
+case 2:case 3:case 4:case 5:case 6:if(c.ExtraMode&&!c.SafeMode){b.x("<h"+(this.v-1+1).toString());var k=this.aX(c);if(k)
+{b.x(' id="');b.x(k);b.x('">')}else b.x(">")}else b.x("<h"+(this.v-1+1).toString()+">");c.bz.ae(b,this.E,this.R,this.N);
+b.x("</h"+(this.v-1+1).toString()+">\n");break;case 14:b.x("<hr />\n");return;case 10:case 11:b.x("<li>");c.bz.ae(b,this
+.E,this.R,this.N);b.x("</li>\n");break;case 15:b.x(this.E.substr(this.R,this.N));return;case 16:b.au(this.E,this.R,this.
+N);return;case 18:b.x("<pre");if(c.FormatCodeBlockAttributes!=null)b.x(c.FormatCodeBlockAttributes(this.X));b.x(
+"><code>");var h=b;if(c.FormatCodeBlock){h=b;b=new F()}for(var e=0;e<this.C.length;e++){var j=this.C[e];b.av(j.E,j.R,j.N
+);b.x("\n")}if(c.FormatCodeBlock){h.x(c.FormatCodeBlock(b.bh(),this.X));b=h}b.x("</code></pre>\n\n");return;case 9:b.x(
+"<blockquote>\n");this.aN(c,b);b.x("</blockquote>\n");return;case 19:b.x("<li>\n");this.aN(c,b);b.x("</li>\n");return;
+case 20:b.x("<ol>\n");this.aN(c,b);b.x("</ol>\n");return;case 21:b.x("<ul>\n");this.aN(c,b);b.x("</ul>\n");return;case 
+22:var g=this.X,n=g.name.toLowerCase();if(n=="a")c.OnPrepareLink(g);else if(n=="img")c.OnPrepareImage(g,c.
+RenderingTitledImage);g.aS(b);b.x("\n");this.aN(c,b);g.aO(b);b.x("\n");return;case 23:case 28:this.aN(c,b);return;case 
+24:this.X.l(c,b);return;case 25:b.x("<dd>");if(this.C!=null){b.x("\n");this.aN(c,b)}else c.bz.ae(b,this.E,this.R,this.N)
+;b.x("</dd>\n");break;case 26:if(this.C==null){var m=this.an().split("\n");for(var e=0;e<m.length;e++){var o=m[e];b.x(
+"<dt>");c.bz.af(b,ay(o));b.x("</dt>\n")}}else{b.x("<dt>\n");this.aN(c,b);b.x("</dt>\n")}break;case 27:b.x("<dl>\n");this
+.aN(c,b);b.x("</dl>\n");return;case 29:b.x("<p>");if(this.N>0){c.bz.ae(b,this.E,this.R,this.N);b.x("&nbsp;")}b.x(this.X)
+;b.x("</p>\n");break}};a.aY=function(){this.v=12;this.R=this.ay;this.N=this.aA};a.ao=function(){return this.R+this.N};a.
+a3=function(b){this.N=b-this.R};a.aq=function(){var c=0;for(var b=this.ay;b<this.ay+this.aA;b++)if(this.E.charAt(b)==" "
+)c++;else break;return c};a.V=function(b){this.v=b.v;this.E=b.E;this.R=b.R;this.N=b.N;this.ay=b.ay;this.aA=b.aA;
+return this};function D(b,c){this.bw=b;this.bx=0;this.bo=c}a=D.prototype;a.aH=function(c){var b=new G(c);return this.a1(
+b)};a.aL=function(g,e,b){var c=new G(g,e,b);return this.a1(c)};a.bi=function(b,c,e){if(e.length>1)return false;if(e.
+length==1){var g=b.by;b.by=e[0].ay;c.bu=c.aG(b);if(c.bu==null)return false;b.by=g;e.length=0}while(true){var g=b.by,h=c.
+aG(b);if(h!=null){c.bA.push(h);continue}b.by=g;break}return true};a.a1=function(j){var e=[],c=[],k=-1;while(!j.J()){var 
+m=k==0,b=this.ab(j);k=b.v;if(b.v==25)b.X=m;if(b.v==7||b.v==8){if(c.length>0){var g=c.pop();this.S(e,c);if(g.v!=0){g.aY()
+;g.v=b.v==7?1:2;e.push(g);continue}}if(b.v==7){b.aY();c.push(b)}else if(b.N>=3){b.v=14;e.push(b)}else{b.aY();c.push(b)}
+continue}var h=c.length>0?c[0].v:0;if(b.v==24){var o=b.X,n=j.by;if(!this.bi(j,o,c)){j.by=n;b.aY()}else{e.push(b);
+continue}}switch(b.v){case 0:switch(h){case 0:this.ai(b);break;case 12:this.S(e,c);this.ai(b);break;case 9:case 10:case 
+11:case 25:case 28:case 13:c.push(b);break}break;case 12:switch(h){case 0:case 12:c.push(b);break;case 9:case 10:case 11
+:case 25:case 28:var g=c[c.length-1];if(g.v==0){this.S(e,c);c.push(b)}else c.push(b);break;case 13:this.S(e,c);c.push(b)
+;break}break;case 13:switch(h){case 0:c.push(b);break;case 12:case 9:var g=c[c.length-1];if(g.v==0){this.S(e,c);c.push(b
+)}else{b.aY();c.push(b)}break;case 10:case 11:case 13:case 25:case 28:c.push(b);break}break;case 9:if(h!=9)this.S(e,c);c
+.push(b);break;case 10:case 11:switch(h){case 0:c.push(b);break;case 12:case 9:var g=c[c.length-1];if(g.v==0||this.bx==
+10||this.bx==11||this.bx==25){this.S(e,c);c.push(b)}else{b.aY();c.push(b)}break;case 10:case 11:if(b.v!=10&&b.v!=11)this
+.S(e,c);c.push(b);break;case 25:case 28:if(b.v!=h)this.S(e,c);c.push(b);break;case 13:this.S(e,c);c.push(b);break}break;
+case 25:case 28:switch(h){case 0:case 12:case 25:case 28:this.S(e,c);c.push(b);break;default:b.aY();c.push(b);break}
+break;default:this.S(e,c);e.push(b);break}}this.S(e,c);if(this.bw.ExtraMode)this.I(e);return e};a.T=function(c){var b;
+if(this.bw.bC.length>1)b=this.bw.bC.pop();else b=new B();b.ay=c;return b};a.ai=function(b){this.bw.bC.push(b)};a.aj=
+function(b){for(var c=0;c<b.length;c++)this.bw.bC.push(b[c]);b.length=0};a.aQ=function(g){var b=this.bw.as();for(var c=0
+;c<g.length;c++){var e=g[c];b.x(e.E.substr(e.R,e.N));b.x("\n")}return b.bh()};a.S=function(c,b){while(b.length>0&&b[b.
+length-1].v==0)this.ai(b.pop());if(b.length==0)return;switch(b[0].v){case 12:var h=this.T(b[0].ay);h.v=12;h.E=b[0].E;h.R
+=b[0].R;h.a3(b[b.length-1].ao());c.push(h);this.aj(b);break;case 9:var p=this.aQ(b),o=new D(this.bw,this.bo);o.bx=9;var 
+n=this.T(b[0].ay);n.v=9;n.C=o.aH(p);this.aj(b);c.push(n);break;case 10:case 11:c.push(this.M(b));break;case 25:if(c.
+length>0){var j=c[c.length-1];switch(j.v){case 12:j.v=26;break;case 25:break;default:var k=this.T(j.ay);k.v=26;k.C=[];k.
+C.push(j);c.pop();c.push(k);break}}c.push(this.G(b));break;case 28:this.bw.z(this.L(b));break;case 13:var e=this.T(b[0].
+ay);e.v=18;e.C=[];var g=b[0].an();if(g.substr(0,2)=="{{"&&g.substr(g.length-2,2)=="}}"){e.X=g.substr(2,g.length-4);b.
+splice(0,1)}for(var m=0;m<b.length;m++)e.C.push(b[m]);c.push(e);b.length=0;break}};a.ab=function(c){var b=this.T(c.by);b
+.E=c.E;b.R=c.by;b.N=-1;b.v=this.ac(c,b);if(b.N<0){c.bb();b.N=c.by-b.R}b.aA=c.by-b.ay;c.aZ();return b};a.ac=function(b,c)
+{if(b.Y())return 0;var h=b.by,e=b.H();if(e=="#"){var j=1;b.a5(1);while(b.H()=="#"){j++;b.a5(1)}if(j>6)j=6;b.a8();c.R=b.
+by;b.bb();if(this.bw.ExtraMode&&!this.bw.SafeMode){var m=at(b.E,c.R,b.by);if(m!=null){c.X=m.id;b.by=m.end}}while(b.by>c.
+R&&b.F(-1)=="#")b.a5(-1);while(b.by>c.R&&ad(b.F(-1)))b.a5(-1);c.N=b.by-c.R;b.bb();return 1+j-1}if(e=="-"||e=="="){var k=
+e;while(b.H()==k)b.a5(1);b.a8();if(b.Y())return k=="="?7:8;b.by=h}if(this.bw.ExtraMode){var s=av(b);if(s!=null){c.X=s;
+return 24}b.by=h;if(e=="~"||e=="`"){if(this.aJ(b,c))return c.v;b.by=h}}var g=-1,r=0;while(!b.Y()){if(b.H()==" "){if(g<0)
+r++}else if(b.H()=="\t"){if(g<0)g=b.by}else break;b.a5(1)}if(b.Y()){c.N=0;return 0}if(r>=4){c.R=h+4;return 13}if(g>=0&&g
+-h<4){c.R=g+1;return 13}c.R=b.by;e=b.H();if(e=="<"){if(this.a0(b,c))return c.v;b.by=c.R}if(e==">"){if(ab(b.F(1))){b.a5(2
+);c.R=b.by;return 9}b.a5(1);c.R=b.by;return 9}if(e=="-"||e=="_"||e=="*"){var o=0;while(!b.Y()){var k=b.H();if(b.H()==e){
+o++;b.a5(1);continue}if(ab(b.H())){b.a5(1);continue}break}if(b.Y()&&o>=3)return 14;b.by=c.R}if(this.bw.ExtraMode&&e=="*"
+&&b.F(1)=="["){b.a5(2);b.a8();b.az();while(!b.Y()&&b.H()!="]")b.a5(1);var n=ay(b.W());if(b.H()=="]"&&b.F(1)==":"&&n){b.
+a5(2);b.a8();b.az();b.bb();var v=b.W();this.bw.y(n,v);return 0}b.by=c.R}if((e=="*"||e=="+"||e=="-")&&ab(b.F(1))){b.a5(1)
+;b.a8();c.R=b.by;return 11}if(e==":"&&this.bw.ExtraMode&&ab(b.F(1))){b.a5(1);b.a8();c.R=b.by;return 25}if(X(e)){b.a5(1);
+while(X(b.H()))b.a5(1);if(b.aW(".")&&b.a8()){c.R=b.by;return 10}b.by=c.R}if(e=="["){if(this.bw.ExtraMode&&b.F(1)=="^"){
+var t=b.by;b.a5(2);var p=b.a4();if(p!=null&&b.aW("]")&&b.aW(":")){b.a8();c.R=b.by;c.X=p;return 28}b.by=t}var q=an(b,this
+.bw.ExtraMode);if(q!=null){this.bw.A(q);return 0}}return 12};a.ar=function(c){var b=c.attributes.markdown;if(b==
+undefined)if(this.bo)return 3;else return 0;delete c.attributes.markdown;if(b=="1")return(c.ap()&8)!=0?2:1;if(b=="block"
+)return 1;if(b=="deep")return 3;if(b=="span")return 2;return 4};a.aK=function(b,e,o,m){var g=b.by,k=1,j=false;while(!b.J
+()){if(!b.Z("<"))break;var n=b.by,h=ag(b);if(h==null){b.a5(1);continue}if(this.bw.SafeMode&&m==4&&!j)if(!h.at())j=true;
+if(h.closed)continue;if(h.name==o.name)if(h.closing){k--;if(k==0){b.a8();b.aZ();e.v=22;e.X=o;e.a3(b.by);switch(m){case 2
+:var c=this.T(g);c.E=b.E;c.v=17;c.R=g;c.N=n-g;e.C=[];e.C.push(c);break;case 1:case 3:var p=new D(this.bw,m==3);e.C=p.aL(
+b.E,g,n-g);break;case 4:if(j){e.v=16;e.a3(b.by)}else{var c=this.T(g);c.E=b.E;c.v=15;c.R=g;c.N=n-g;e.C=[];e.C.push(c)}
+break}return true}}else k++}return false};a.a0=function(b,c){var g=b.by,h=ag(b);if(h==null)return false;if(h.closing)
+return false;var m=false;if(this.bw.SafeMode&&!h.at()||!this.bw.AllowUserHtml)m=true;var q=h.ap();if((q&1)==0)
+return false;if((q&4)!=0||h.closed){b.a8();b.aZ();c.N=b.by-c.R;c.v=m?16:15;return true}if((q&2)!=0){b.a8();if(!b.Y())
+return false}var o=this.bw.ExtractHeadBlocks&&h.name.toLowerCase()=="head",t=b.by;if(!o&&this.bw.ExtraMode){var n=this.
+ar(h);if(n!=0)return this.aK(b,c,h,n)}var k=null,p=1;while(!b.J()){if(!b.Z("<"))break;var s=b.by,j=ag(b);if(j==null){b.
+a5(1);continue}if(this.bw.SafeMode&&!j.at())m=true;if(j.closed)continue;if(!o&&!j.closing&&this.bw.ExtraMode&&!m){var n=
+this.ar(j);if(n!=0){var r=this.T(g);if(this.aK(b,r,j,n)){if(k==null)k=[];if(s>g){var e=this.T(g);e.E=b.E;e.v=15;e.R=g;e.
+N=s-g;k.push(e)}k.push(r);g=b.by;continue}else this.ai(r)}}if(j.name==h.name&&!j.closed)if(j.closing){p--;if(p==0){b.a8(
+);b.aZ();if(m){c.v=16;c.a3(b.by);return true}if(k!=null){if(b.by>g){var e=this.T(g);e.E=b.E;e.v=15;e.R=g;e.N=b.by-g;k.
+push(e)}c.v=23;c.a3(b.by);c.C=k;return true}if(o){var v=b.E.substr(t,s-t);this.bw.HeadBlockContent=this.bw.
+HeadBlockContent+ay(v)+"\n";c.v=15;c.R=b.bK;c.contentEnd=b.bK;c.ay=b.bK;return true}c.v=15;c.N=b.by-c.R;return true}}
+else p++}return 0};a.M=function(b){var r=b[0].v,t=b[0].aq();for(var c=1;c<b.length;c++){if(b[c].v==12&&(b[c-1].v==12||b[
+c-1].v==11||b[c-1].v==10)){b[c-1].a3(b[c].ao());this.ai(b[c]);b.splice(c,1);c--;continue}if(b[c].v!=13&&b[c].v!=0){var s
+=b[c].aq();if(s>t){b[c].v=13;var v=b[c].ao();b[c].R=b[c].ay+s;b[c].a3(v)}}}var h=this.T(0);h.v=r==11?21:20;h.C=[];for(
+var c=0;c<b.length;c++){var k=c;while(k>0&&b[k-1].v==0)k--;var g=c;while(g<b.length-1&&b[g+1].v!=11&&b[g+1].v!=10)g++;
+if(k==g)h.C.push(this.T().V(b[c]));else{var o=false,n=this.bw.as();for(var e=k;e<=g;e++){var m=b[e];n.x(m.E.substr(m.R,m
+.N));n.x("\n");if(b[e].v==0)o=true}var j=this.T();j.v=19;j.ay=b[k].ay;var p=new D(this.bw);p.bx=r;j.C=p.aH(n.bh());if(!o
+)for(var e=0;e<j.C.length;e++){var q=j.C[e];if(q.v==12)q.v=17}h.C.push(j)}c=g}h.ay=h.C[0].ay;this.aj(b);b.length=0;
+return h};a.G=function(b){for(var c=1;c<b.length;c++)if(b[c].v==12&&(b[c-1].v==12||b[c-1].v==25)){b[c-1].a3(b[c].ao());
+this.ai(b[c]);b.splice(c,1);c--;continue}var k=b[0].X;if(b.length==1&&!k){var m=b[0];b.length=0;return m}var h=this.bw.
+as();for(var c=0;c<b.length;c++){var g=b[c];h.x(g.E.substr(g.R,g.N));h.x("\n")}var e=this.T(b[0].ay);e.v=25;var j=new D(
+this.bw);j.bx=25;e.C=j.aH(h.bh());this.aj(b);b.length=0;return e};a.I=function(e){var c=null;for(var b=0;b<e.length;b++)
+switch(e[b].v){case 26:case 25:if(c==null){c=this.T(e[b].ay);c.v=27;c.C=[];e.splice(b,0,c);b++}c.C.push(e[b]);e.splice(b
+,1);b--;break;default:c=null;break}};a.L=function(c){for(var b=1;b<c.length;b++)if(c[b].v==12&&(c[b-1].v==12||c[b-1].v==
+28)){c[b-1].a3(c[b].ao());this.ai(c[b]);c.splice(b,1);b--;continue}var h=this.bw.as();for(var b=0;b<c.length;b++){var g=
+c[b];h.x(g.E.substr(g.R,g.N));h.x("\n")}var j=new D(this.bw);j.bx=28;var e=this.T(c[0].ay);e.v=28;e.X=c[0].X;e.C=j.aH(h.
+bh());this.aj(c);c.length=0;return e};a.aJ=function(b,e){var m=b.by,k=b.H();b.az();while(b.H()==k)b.a5(1);var g=b.W();
+if(g.length<3)return false;b.a8();if(!b.Y())return false;b.aZ();var j=b.by;if(!b.Z(g))return false;if(!Y(b.F(-1)))
+return false;var h=b.by;b.a5(g.length);b.a8();if(!b.Y())return false;e.v=18;e.C=[];h--;var c=this.T(m);c.v=13;c.E=b.E;c.
+R=j;c.N=h-j;e.C.push(c);return true};function H(){this.bp=[];this.bu=null;this.bA=[]}a=H.prototype;a.ax=false;a.bk=false
+;a.aG=function(b){b.a8();if(b.Y())return null;var e=this.ax;if(this.ax&&!b.aW("|")){e=true;return null}var c=[];while(!b
+.Y()){b.az();while(!b.Y()&&b.H()!="|")b.a2(true);c.push(ay(b.W()));e|=b.aW("|")}if(!e)return null;while(c.length<this.bp
+.length)c.push("&nbsp;");b.aZ();return c};a.aT=function(h,b,e,g){for(var c=0;c<e.length;c++){b.x("\t<");b.x(g);if(c<this
+.bp.length)switch(this.bp[c]){case 1:b.x(' align="left"');break;case 2:b.x(' align="right"');break;case 3:b.x(
+' align="center"');break}b.x(">");h.bz.af(b,e[c]);b.x("</");b.x(g);b.x(">\n")}};a.l=function(e,b){b.x("<table>\n");if(
+this.bu!=null){b.x("<thead>\n<tr>\n");this.aT(e,b,this.bu,"th");b.x("</tr>\n</thead>\n")}b.x("<tbody>\n");for(var c=0;c<
+this.bA.length;c++){var g=this.bA[c];b.x("<tr>\n");this.aT(e,b,g,"td");b.x("</tr>\n")}b.x("</tbody>\n");b.x("</table>\n"
+)};function av(b){b.a8();if(b.H()!="|"&&b.H()!=":"&&b.H()!="-")return null;var c=null;if(b.aW("|")){c=new H();c.ax=true}
+while(true){b.a8();if(b.H()=="|")return null;var g=b.aW(":");while(b.H()=="-")b.a5(1);var h=b.aW(":");b.a8();var e=0;if(
+g&&h)e=3;else if(g)e=1;else if(h)e=2;if(b.Y()){if(c==null)return null;c.bp.push(e);return c}if(!b.aW("|"))return null;
+if(c==null)c=new H();c.bp.push(e);b.a8();if(b.Y()){c.bk=true;return c}}}this.Markdown=i;this.HtmlTag=w})();if(typeof 
+exports!=="undefined")exports.Markdown=MarkdownDeep.Markdown

--- a/MarkdownDeepJS/MarkdownDeepLib.min.js
+++ b/MarkdownDeepJS/MarkdownDeepLib.min.js
@@ -6,27 +6,27 @@ if(b[c]===e)return c;return-1}function i(){this.bz=new E(this);this.bC=[];this.b
 SafeMode:false,ExtraMode:false,MarkdownInHtml:false,AutoHeadingIDs:false,UrlBaseLocation:null,UrlRootLocation:null,
 NewWindowForExternalLinks:false,NewWindowForLocalLinks:false,NoFollowLinks:false,NoFollowExternalLinks:false,
 HtmlClassFootnotes:"footnotes",HtmlClassTitledImages:null,RenderingTitledImage:false,FormatCodeBlockAttributes:null,
-FormatCodeBlock:null,ExtractHeadBlocks:false,HeadBlockContent:""};var a=i.prototype;function ao(b,c,e,g){return b.slice(
-0,c).concat(g).concat(b.slice(c+e))}i.prototype.GetListItems=function(k,n){var c=this.aE(k),b;for(b=0;b<c.length;b++){
-var e=c[b];if((e.v==23||e.v==15||e.v==22)&&e.C){c=ao(c,b,1,e.C);b--;continue}if(n<e.ay)break}b--;if(b<0)return null;var 
-h=c[b];if(h.v!=21&&h.v!=20)return null;var g=[],m=h.C;for(var j=0;j<m.length;j++)g.push(m[j].ay);b++;if(b<c.length)g.
-push(c[b].ay);else g.push(k.length);return g};i.prototype.Transform=function(c){var n=c.indexOf("\r");if(n>=0){var m=c.
-indexOf("\n");if(m>=0)if(m<n)c=c.replace(/\n\r/g,"\n");else c=c.replace(/\r\n/g,"\n");c=c.replace(/\r/g,"\n")}this.
-HeadBlockContent="";var k=this.aE(c);if(this.bn!=null){var j=[];for(var r in this.bn)j.push(this.bn[r]);j.sort(function(
-p,q){return q.Abbr.length-p.Abbr.length});this.bn=j}var b=this.bF;b.K();for(var g=0;g<k.length;g++){var s=k[g];s.l(this,
-b)}if(this.bI.length>0){b.x('\n<div class="');b.x(this.HtmlClassFootnotes);b.x('">\n');b.x("<hr />\n");b.x("<ol>\n");
-for(var g=0;g<this.bI.length;g++){var h=this.bI[g];b.x('<li id="fn:');b.x(h.X);b.x('">\n');var o='<a href="#fnref:'+h.X+
-'" rev="footnote">&#8617;</a>',e=h.C[h.C.length-1];if(e.v==12){e.v=29;e.X=o}else{e=new B();e.N=0;e.v=29;e.X=o;h.C.push(e
-)}h.l(this,b);b.x("</li>\n")}b.x("</ol>\n");b.x("</div>\n")}return b.bh()};i.prototype.OnQualifyUrl=function(b){if(au(b,
-"#"))return b;if(aj(b))return b;if(au(b,"/")){var e=this.UrlRootLocation;if(!e){if(!this.UrlBaseLocation)return b;var c=
-this.UrlBaseLocation.indexOf("://");if(c==-1)c=0;else c+=3;c=this.UrlBaseLocation.indexOf("/",c);e=c<0?this.
-UrlBaseLocation:this.UrlBaseLocation.substr(0,c)}return e+b}else{if(!this.UrlBaseLocation)return b;if(!T(this.
-UrlBaseLocation,"/"))return this.UrlBaseLocation+"/"+b;else return this.UrlBaseLocation+b}};i.prototype.OnGetImageSize=
-function(b,c){return null};i.prototype.OnPrepareLink=function(b){var c=b.attributes.href;if(this.NoFollowLinks)b.
-attributes.rel="nofollow";if(this.NoFollowExternalLinks)if(aj(c))b.attributes.rel="nofollow";if(this.
-NewWindowForExternalLinks&&aj(c)||this.NewWindowForLocalLinks&&!aj(c))b.attributes.target="_blank";b.attributes.href=
-this.OnQualifyUrl(c)};i.prototype.OnPrepareImage=function(b,e){var c=this.OnGetImageSize(b.attributes.src,e);if(c!=null)
-{b.attributes.width=c.width;b.attributes.height=c.height}b.attributes.src=this.OnQualifyUrl(b.attributes.src)};i.
+FormatCodeBlock:null,ExtractHeadBlocks:false,HeadBlockContent:"",AllowUserHtml:true};var a=i.prototype;function ao(b,c,e
+,g){return b.slice(0,c).concat(g).concat(b.slice(c+e))}i.prototype.GetListItems=function(k,n){var c=this.aE(k),b;for(b=0
+;b<c.length;b++){var e=c[b];if((e.v==23||e.v==15||e.v==22)&&e.C){c=ao(c,b,1,e.C);b--;continue}if(n<e.ay)break}b--;if(b<0
+)return null;var h=c[b];if(h.v!=21&&h.v!=20)return null;var g=[],m=h.C;for(var j=0;j<m.length;j++)g.push(m[j].ay);b++;
+if(b<c.length)g.push(c[b].ay);else g.push(k.length);return g};i.prototype.Transform=function(c){var n=c.indexOf("\r");
+if(n>=0){var m=c.indexOf("\n");if(m>=0)if(m<n)c=c.replace(/\n\r/g,"\n");else c=c.replace(/\r\n/g,"\n");c=c.replace(/\r/g
+,"\n")}this.HeadBlockContent="";var k=this.aE(c);if(this.bn!=null){var j=[];for(var r in this.bn)j.push(this.bn[r]);j.
+sort(function(p,q){return q.Abbr.length-p.Abbr.length});this.bn=j}var b=this.bF;b.K();for(var g=0;g<k.length;g++){var s=
+k[g];s.l(this,b)}if(this.bI.length>0){b.x('\n<div class="');b.x(this.HtmlClassFootnotes);b.x('">\n');b.x("<hr />\n");b.x
+("<ol>\n");for(var g=0;g<this.bI.length;g++){var h=this.bI[g];b.x('<li id="fn:');b.x(h.X);b.x('">\n');var o=
+'<a href="#fnref:'+h.X+'" rev="footnote">&#8617;</a>',e=h.C[h.C.length-1];if(e.v==12){e.v=29;e.X=o}else{e=new B();e.N=0;
+e.v=29;e.X=o;h.C.push(e)}h.l(this,b);b.x("</li>\n")}b.x("</ol>\n");b.x("</div>\n")}return b.bh()};i.prototype.
+OnQualifyUrl=function(b){if(au(b,"#"))return b;if(aj(b))return b;if(au(b,"/")){var e=this.UrlRootLocation;if(!e){if(!
+this.UrlBaseLocation)return b;var c=this.UrlBaseLocation.indexOf("://");if(c==-1)c=0;else c+=3;c=this.UrlBaseLocation.
+indexOf("/",c);e=c<0?this.UrlBaseLocation:this.UrlBaseLocation.substr(0,c)}return e+b}else{if(!this.UrlBaseLocation)
+return b;if(!T(this.UrlBaseLocation,"/"))return this.UrlBaseLocation+"/"+b;else return this.UrlBaseLocation+b}};i.
+prototype.OnGetImageSize=function(b,c){return null};i.prototype.OnPrepareLink=function(b){var c=b.attributes.href;if(
+this.NoFollowLinks)b.attributes.rel="nofollow";if(this.NoFollowExternalLinks)if(aj(c))b.attributes.rel="nofollow";if(
+this.NewWindowForExternalLinks&&aj(c)||this.NewWindowForLocalLinks&&!aj(c))b.attributes.target="_blank";b.attributes.
+href=this.OnQualifyUrl(c)};i.prototype.OnPrepareImage=function(b,e){var c=this.OnGetImageSize(b.attributes.src,e);if(c!=
+null){b.attributes.width=c.width;b.attributes.height=c.height}b.attributes.src=this.OnQualifyUrl(b.attributes.src)};i.
 prototype.GetLinkDefinition=function(b){if(this.bv.hasOwnProperty(b))return this.bv[b];else return null};a.aE=function(b
 ){this.bv=[];this.bs=[];this.bI=[];this.bJ=[];this.bn=null;return new D(this,this.MarkdownInHtml).aH(b)};a.A=function(b)
 {this.bv[b.id]=b};a.z=function(b){this.bs[b.X]=b};a.Q=function(c){var b=this.bs[c];if(b!=undefined){this.bI.push(b);
@@ -150,152 +150,152 @@ b.x("<abbr");if(e.Title){b.x(' title="');b.au(e.Title,0,e.Title.length);b.x('"')
 this.bw.am(),o=k==null?/[\*\_\`\[\!\<\&\ \\]/g:null,q=this.bw.ExtraMode,g=b.by;while(!b.J()){if(o!=null&&!b.aa(o))break;
 var m=b.by,c=null;switch(b.H()){case"*":case"_":c=this.P();if(c!=null)switch(c.type){case 13:case 11:case 12:if(h==null)
 h=[];h.push(c);break}break;case"`":c=this.aF();break;case"[":case"!":var t=b.by;c=this.aI();if(c==null)b.by=t;break;case
-"<":var e=b.by,p=ag(b);if(p!=null)if(!this.bw.SafeMode||p.at())c=this.U(1,e,b.by-e);else b.by=e;else{b.by=e;c=this.aD();
-if(c==null)b.by=e}break;case"&":var e=b.by;if(b.a6())c=this.U(2,e,b.by-e);break;case" ":if(b.F(1)==" "&&Y(b.F(2))){b.a5(
-2);if(!b.J()){b.aZ();c=this.U(8,m,0)}}break;case"\\":if(U(b.F(1),q)){c=this.U(0,b.by+1,1);b.a5(2)}break}if(c==null&&k!=
-null&&!R(b.F(-1))){var v=b.by;for(var r in k){var n=k[r];if(b.a9(n.Abbr)&&!R(b.H())){c=this.O(15,n);break}b.bK=v}}if(c!=
-null){if(m>g)j.push(this.U(0,g,m-g));j.push(c);g=b.by}else b.a5(1)}if(b.by>g)j.push(this.U(0,g,b.by-g));if(h!=null)this.
-aV(j,h)};a.P=function(){var b=this.bB,e=b.H(),k=e=="*"?"_":"*",c=b.by;if(b.D()||ad(b.F(-1))){while(ae(b.H()))b.a5(1);if(
-b.J()||ad(b.H()))return this.U(2,c,b.by-c);b.by=c}while(ae(b.F(-1)))b.a5(-1);var h=b.D()||ad(b.F(-1));b.by=c;while(b.H()
-==e)b.a5(1);var j=b.by-c;while(ae(b.F(1)))b.a5(1);var g=b.J()||ad(b.H());b.by=c+j;if(h)return this.U(11,c,b.by-c);if(g)
-return this.U(12,c,b.by-c);if(this.bw.ExtraMode&&e=="_"&&R(b.H()))return null;return this.U(13,c,b.by-c)};a.bg=function(
-h,g,b,c){var e=this.U(b.type,b.startOffset+c,b.length-c);b.length=c;g.splice(S(g,b)+1,0,e);h.splice(S(h,b)+1,0,e);
-return e};a.aV=function(n,b){var m=this.bB.E,j=true;while(j){j=false;for(var h=0;h<b.length;h++){var c=b[h];if(c.type!=
-11&&c.type!=13)continue;for(var k=h+1;k<b.length;k++){var g=b[k];if(g.type!=12&&g.type!=13)break;if(m.charAt(c.
-startOffset)!=m.charAt(g.startOffset))continue;var e=Math.min(c.length,g.length);if(e>=3)e=e%2==1?1:2;if(c.length>e){c=
-this.bg(n,b,c,c.length-e);h--}if(g.length>e)this.bg(n,b,g,e);c.type=e==1?3:5;g.type=e==1?4:6;b.splice(S(b,c),1);b.splice
-(S(b,g),1);j=true;break}}}};a.aD=function(){if(this.br)return null;var c=this.bB;c.a5(1);c.az();var j=this.bw.ExtraMode;
-while(!c.J()){var h=c.H();if(ad(h))break;if(h==">"){var b=az(c.W(),j),e=null;if(ah(b)){var g;if(b.toLowerCase().substr(0
-,7)=="mailto:")g=b.substr(7);else{g=b;b="mailto:"+b}e=new am(new C("auto",b,null),g)}else if(al(b))e=new am(new C("auto"
-,b,null),b);if(e!=null){c.a5(1);return this.O(9,e)}return null}c.a2(j)}return null};a.aI=function(){var b=this.bB,h=b.aW
-("!")?10:9;if(!b.aW("["))return null;var o=this.by;if(this.bw.ExtraMode&&h==9&&b.aW("^")){b.a8();b.az();var m=b.a4();if(
-m!=null&&b.aW("]")){var s=this.bw.Q(m);if(s>=0)return this.O(14,{index:s,id:m})}this.by=o}if(this.br&&h==9)return null;
-var r=this.bw.ExtraMode;b.az();var j=1;while(!b.J()){var p=b.H();if(p=="[")j++;else if(p=="]"){j--;if(j==0)break}b.a2(r)
-}if(b.J())return null;var n=az(b.W(),r);b.a5(1);o=b.by;if(b.aW("(")){var t=ar(b,null,this.bw.ExtraMode);if(t==null)
-return null;b.bd();if(!b.aW(")"))return null;return this.O(h,new am(t,n))}if(!b.aW(" "))b.aW("\t");if(b.Y()){b.aZ();b.a8
-()}var c=null;if(b.H()=="["){b.a5(1);b.az();if(!b.Z("]"))return null;c=b.W();b.a5(1)}else b.by=o;if(!c){c=n;while(true){
-var k=c.indexOf("\n");if(k<0)break;var g=k;while(g>0&&ad(c.charAt(g-1)))g--;var e=k;while(e<c.length&&ad(c.charAt(e)))
-e++;c=c.substr(0,g)+" "+c.substr(e)}}var q=this.bw.GetLinkDefinition(c);if(q==null)return null;return this.O(h,new am(q,
-n))};a.aF=function(){var b=this.bB,c=b.by,e=0;while(b.aW("`"))e++;b.bd();if(b.J())return this.U(0,c,b.by-c);var g=b.by;
-if(!b.Z(b.E.substr(c,e)))return this.U(0,c,b.by-c);var h=b.by+e;while(ad(b.F(-1)))b.a5(-1);var j=this.U(7,g,b.by-g);b.by
-=h;return j};a.U=function(g,e,c){if(this.bG.length!=0){var b=this.bG.pop();b.type=g;b.startOffset=e;b.length=c;b.X=null;
-return b}else return new ax(g,e,c)};a.O=function(e,c){if(this.bG.length!=0){var b=this.bG.pop();b.type=e;b.X=c;return b}
-else{var b=new ax(e,0,0);b.X=c;return b}};a.ak=function(b){b.X=null;this.bG.push(b)};function B(){}a=B.prototype;a.E=
-null;a.v=0;a.R=0;a.N=0;a.ay=0;a.aA=0;a.C=null;a.X=null;a.an=function(){if(this.E==null)return null;if(this.R==-1)
-return this.E;return this.E.substr(this.R,this.N)};a.al=function(){var c=new F();for(var b=0;b<this.C.length;b++){c.x(
-this.C[b].an());c.x("\n")}return c.bh()};a.aN=function(e,c){for(var b=0;b<this.C.length;b++)this.C[b].l(e,c)};a.aX=
-function(e){if(typeof this.X=="string")return this.X;var c=at(this.E,this.R,this.ao()),b=null;if(c!=null){this.a3(c.end)
-;b=c.id}else b=e.aC(this.E,this.R,this.N);this.X=b;return b};a.l=function(c,b){switch(this.v){case 0:return;case 12:c.bz
-.ah(b,this.E,this.R,this.N);break;case 17:c.bz.ae(b,this.E,this.R,this.N);b.x("\n");break;case 1:case 2:case 3:case 4:
-case 5:case 6:if(c.ExtraMode&&!c.SafeMode){b.x("<h"+(this.v-1+1).toString());var k=this.aX(c);if(k){b.x(' id="');b.x(k);
-b.x('">')}else b.x(">")}else b.x("<h"+(this.v-1+1).toString()+">");c.bz.ae(b,this.E,this.R,this.N);b.x("</h"+(this.v-1+1
-).toString()+">\n");break;case 14:b.x("<hr />\n");return;case 10:case 11:b.x("<li>");c.bz.ae(b,this.E,this.R,this.N);b.x
-("</li>\n");break;case 15:b.x(this.E.substr(this.R,this.N));return;case 16:b.au(this.E,this.R,this.N);return;case 18:b.x
-("<pre");if(c.FormatCodeBlockAttributes!=null)b.x(c.FormatCodeBlockAttributes(this.X));b.x("><code>");var h=b;if(c.
-FormatCodeBlock){h=b;b=new F()}for(var e=0;e<this.C.length;e++){var j=this.C[e];b.av(j.E,j.R,j.N);b.x("\n")}if(c.
-FormatCodeBlock){h.x(c.FormatCodeBlock(b.bh(),this.X));b=h}b.x("</code></pre>\n\n");return;case 9:b.x("<blockquote>\n");
-this.aN(c,b);b.x("</blockquote>\n");return;case 19:b.x("<li>\n");this.aN(c,b);b.x("</li>\n");return;case 20:b.x("<ol>\n"
-);this.aN(c,b);b.x("</ol>\n");return;case 21:b.x("<ul>\n");this.aN(c,b);b.x("</ul>\n");return;case 22:var g=this.X,n=g.
-name.toLowerCase();if(n=="a")c.OnPrepareLink(g);else if(n=="img")c.OnPrepareImage(g,c.RenderingTitledImage);g.aS(b);b.x(
-"\n");this.aN(c,b);g.aO(b);b.x("\n");return;case 23:case 28:this.aN(c,b);return;case 24:this.X.l(c,b);return;case 25:b.x
-("<dd>");if(this.C!=null){b.x("\n");this.aN(c,b)}else c.bz.ae(b,this.E,this.R,this.N);b.x("</dd>\n");break;case 26:if(
-this.C==null){var m=this.an().split("\n");for(var e=0;e<m.length;e++){var o=m[e];b.x("<dt>");c.bz.af(b,ay(o));b.x(
-"</dt>\n")}}else{b.x("<dt>\n");this.aN(c,b);b.x("</dt>\n")}break;case 27:b.x("<dl>\n");this.aN(c,b);b.x("</dl>\n");
-return;case 29:b.x("<p>");if(this.N>0){c.bz.ae(b,this.E,this.R,this.N);b.x("&nbsp;")}b.x(this.X);b.x("</p>\n");break}};a
-.aY=function(){this.v=12;this.R=this.ay;this.N=this.aA};a.ao=function(){return this.R+this.N};a.a3=function(b){this.N=b-
-this.R};a.aq=function(){var c=0;for(var b=this.ay;b<this.ay+this.aA;b++)if(this.E.charAt(b)==" ")c++;else break;return c
-};a.V=function(b){this.v=b.v;this.E=b.E;this.R=b.R;this.N=b.N;this.ay=b.ay;this.aA=b.aA;return this};function D(b,c){
-this.bw=b;this.bx=0;this.bo=c}a=D.prototype;a.aH=function(c){var b=new G(c);return this.a1(b)};a.aL=function(g,e,b){var 
-c=new G(g,e,b);return this.a1(c)};a.bi=function(b,c,e){if(e.length>1)return false;if(e.length==1){var g=b.by;b.by=e[0].
-ay;c.bu=c.aG(b);if(c.bu==null)return false;b.by=g;e.length=0}while(true){var g=b.by,h=c.aG(b);if(h!=null){c.bA.push(h);
-continue}b.by=g;break}return true};a.a1=function(j){var e=[],c=[],k=-1;while(!j.J()){var m=k==0,b=this.ab(j);k=b.v;if(b.
-v==25)b.X=m;if(b.v==7||b.v==8){if(c.length>0){var g=c.pop();this.S(e,c);if(g.v!=0){g.aY();g.v=b.v==7?1:2;e.push(g);
-continue}}if(b.v==7){b.aY();c.push(b)}else if(b.N>=3){b.v=14;e.push(b)}else{b.aY();c.push(b)}continue}var h=c.length>0?c
-[0].v:0;if(b.v==24){var o=b.X,n=j.by;if(!this.bi(j,o,c)){j.by=n;b.aY()}else{e.push(b);continue}}switch(b.v){case 0:
-switch(h){case 0:this.ai(b);break;case 12:this.S(e,c);this.ai(b);break;case 9:case 10:case 11:case 25:case 28:case 13:c.
-push(b);break}break;case 12:switch(h){case 0:case 12:c.push(b);break;case 9:case 10:case 11:case 25:case 28:var g=c[c.
-length-1];if(g.v==0){this.S(e,c);c.push(b)}else c.push(b);break;case 13:this.S(e,c);c.push(b);break}break;case 13:
-switch(h){case 0:c.push(b);break;case 12:case 9:var g=c[c.length-1];if(g.v==0){this.S(e,c);c.push(b)}else{b.aY();c.push(
-b)}break;case 10:case 11:case 13:case 25:case 28:c.push(b);break}break;case 9:if(h!=9)this.S(e,c);c.push(b);break;case 
-10:case 11:switch(h){case 0:c.push(b);break;case 12:case 9:var g=c[c.length-1];if(g.v==0||this.bx==10||this.bx==11||this
-.bx==25){this.S(e,c);c.push(b)}else{b.aY();c.push(b)}break;case 10:case 11:if(b.v!=10&&b.v!=11)this.S(e,c);c.push(b);
-break;case 25:case 28:if(b.v!=h)this.S(e,c);c.push(b);break;case 13:this.S(e,c);c.push(b);break}break;case 25:case 28:
-switch(h){case 0:case 12:case 25:case 28:this.S(e,c);c.push(b);break;default:b.aY();c.push(b);break}break;default:this.S
-(e,c);e.push(b);break}}this.S(e,c);if(this.bw.ExtraMode)this.I(e);return e};a.T=function(c){var b;if(this.bw.bC.length>1
-)b=this.bw.bC.pop();else b=new B();b.ay=c;return b};a.ai=function(b){this.bw.bC.push(b)};a.aj=function(b){for(var c=0;c<
-b.length;c++)this.bw.bC.push(b[c]);b.length=0};a.aQ=function(g){var b=this.bw.as();for(var c=0;c<g.length;c++){var e=g[c
-];b.x(e.E.substr(e.R,e.N));b.x("\n")}return b.bh()};a.S=function(c,b){while(b.length>0&&b[b.length-1].v==0)this.ai(b.pop
-());if(b.length==0)return;switch(b[0].v){case 12:var h=this.T(b[0].ay);h.v=12;h.E=b[0].E;h.R=b[0].R;h.a3(b[b.length-1].
-ao());c.push(h);this.aj(b);break;case 9:var p=this.aQ(b),o=new D(this.bw,this.bo);o.bx=9;var n=this.T(b[0].ay);n.v=9;n.C
-=o.aH(p);this.aj(b);c.push(n);break;case 10:case 11:c.push(this.M(b));break;case 25:if(c.length>0){var j=c[c.length-1];
-switch(j.v){case 12:j.v=26;break;case 25:break;default:var k=this.T(j.ay);k.v=26;k.C=[];k.C.push(j);c.pop();c.push(k);
-break}}c.push(this.G(b));break;case 28:this.bw.z(this.L(b));break;case 13:var e=this.T(b[0].ay);e.v=18;e.C=[];var g=b[0]
-.an();if(g.substr(0,2)=="{{"&&g.substr(g.length-2,2)=="}}"){e.X=g.substr(2,g.length-4);b.splice(0,1)}for(var m=0;m<b.
-length;m++)e.C.push(b[m]);c.push(e);b.length=0;break}};a.ab=function(c){var b=this.T(c.by);b.E=c.E;b.R=c.by;b.N=-1;b.v=
-this.ac(c,b);if(b.N<0){c.bb();b.N=c.by-b.R}b.aA=c.by-b.ay;c.aZ();return b};a.ac=function(b,c){if(b.Y())return 0;var h=b.
-by,e=b.H();if(e=="#"){var j=1;b.a5(1);while(b.H()=="#"){j++;b.a5(1)}if(j>6)j=6;b.a8();c.R=b.by;b.bb();if(this.bw.
-ExtraMode&&!this.bw.SafeMode){var m=at(b.E,c.R,b.by);if(m!=null){c.X=m.id;b.by=m.end}}while(b.by>c.R&&b.F(-1)=="#")b.a5(
--1);while(b.by>c.R&&ad(b.F(-1)))b.a5(-1);c.N=b.by-c.R;b.bb();return 1+j-1}if(e=="-"||e=="="){var k=e;while(b.H()==k)b.a5
-(1);b.a8();if(b.Y())return k=="="?7:8;b.by=h}if(this.bw.ExtraMode){var s=av(b);if(s!=null){c.X=s;return 24}b.by=h;if(e==
-"~"||e=="`"){if(this.aJ(b,c))return c.v;b.by=h}}var g=-1,r=0;while(!b.Y()){if(b.H()==" "){if(g<0)r++}else if(b.H()=="\t"
-){if(g<0)g=b.by}else break;b.a5(1)}if(b.Y()){c.N=0;return 0}if(r>=4){c.R=h+4;return 13}if(g>=0&&g-h<4){c.R=g+1;return 13
-}c.R=b.by;e=b.H();if(e=="<"){if(this.a0(b,c))return c.v;b.by=c.R}if(e==">"){if(ab(b.F(1))){b.a5(2);c.R=b.by;return 9}b.
-a5(1);c.R=b.by;return 9}if(e=="-"||e=="_"||e=="*"){var o=0;while(!b.Y()){var k=b.H();if(b.H()==e){o++;b.a5(1);continue}
-if(ab(b.H())){b.a5(1);continue}break}if(b.Y()&&o>=3)return 14;b.by=c.R}if(this.bw.ExtraMode&&e=="*"&&b.F(1)=="["){b.a5(2
-);b.a8();b.az();while(!b.Y()&&b.H()!="]")b.a5(1);var n=ay(b.W());if(b.H()=="]"&&b.F(1)==":"&&n){b.a5(2);b.a8();b.az();b.
-bb();var v=b.W();this.bw.y(n,v);return 0}b.by=c.R}if((e=="*"||e=="+"||e=="-")&&ab(b.F(1))){b.a5(1);b.a8();c.R=b.by;
-return 11}if(e==":"&&this.bw.ExtraMode&&ab(b.F(1))){b.a5(1);b.a8();c.R=b.by;return 25}if(X(e)){b.a5(1);while(X(b.H()))b.
-a5(1);if(b.aW(".")&&b.a8()){c.R=b.by;return 10}b.by=c.R}if(e=="["){if(this.bw.ExtraMode&&b.F(1)=="^"){var t=b.by;b.a5(2)
-;var p=b.a4();if(p!=null&&b.aW("]")&&b.aW(":")){b.a8();c.R=b.by;c.X=p;return 28}b.by=t}var q=an(b,this.bw.ExtraMode);if(
-q!=null){this.bw.A(q);return 0}}return 12};a.ar=function(c){var b=c.attributes.markdown;if(b==undefined)if(this.bo)
-return 3;else return 0;delete c.attributes.markdown;if(b=="1")return(c.ap()&8)!=0?2:1;if(b=="block")return 1;if(b==
-"deep")return 3;if(b=="span")return 2;return 4};a.aK=function(b,e,o,m){var g=b.by,k=1,j=false;while(!b.J()){if(!b.Z("<")
-)break;var n=b.by,h=ag(b);if(h==null){b.a5(1);continue}if(this.bw.SafeMode&&m==4&&!j)if(!h.at())j=true;if(h.closed)
-continue;if(h.name==o.name)if(h.closing){k--;if(k==0){b.a8();b.aZ();e.v=22;e.X=o;e.a3(b.by);switch(m){case 2:var c=this.
-T(g);c.E=b.E;c.v=17;c.R=g;c.N=n-g;e.C=[];e.C.push(c);break;case 1:case 3:var p=new D(this.bw,m==3);e.C=p.aL(b.E,g,n-g);
-break;case 4:if(j){e.v=16;e.a3(b.by)}else{var c=this.T(g);c.E=b.E;c.v=15;c.R=g;c.N=n-g;e.C=[];e.C.push(c)}break}
-return true}}else k++}return false};a.a0=function(b,c){var g=b.by,h=ag(b);if(h==null)return false;if(h.closing)
-return false;var m=false;if(this.bw.SafeMode&&!h.at())m=true;var q=h.ap();if((q&1)==0)return false;if((q&4)!=0||h.closed
-){b.a8();b.aZ();c.N=b.by-c.R;c.v=m?16:15;return true}if((q&2)!=0){b.a8();if(!b.Y())return false}var o=this.bw.
-ExtractHeadBlocks&&h.name.toLowerCase()=="head",t=b.by;if(!o&&this.bw.ExtraMode){var n=this.ar(h);if(n!=0)return this.aK
-(b,c,h,n)}var k=null,p=1;while(!b.J()){if(!b.Z("<"))break;var s=b.by,j=ag(b);if(j==null){b.a5(1);continue}if(this.bw.
-SafeMode&&!j.at())m=true;if(j.closed)continue;if(!o&&!j.closing&&this.bw.ExtraMode&&!m){var n=this.ar(j);if(n!=0){var r=
-this.T(g);if(this.aK(b,r,j,n)){if(k==null)k=[];if(s>g){var e=this.T(g);e.E=b.E;e.v=15;e.R=g;e.N=s-g;k.push(e)}k.push(r);
-g=b.by;continue}else this.ai(r)}}if(j.name==h.name&&!j.closed)if(j.closing){p--;if(p==0){b.a8();b.aZ();if(m){c.v=16;c.a3
-(b.by);return true}if(k!=null){if(b.by>g){var e=this.T(g);e.E=b.E;e.v=15;e.R=g;e.N=b.by-g;k.push(e)}c.v=23;c.a3(b.by);c.
-C=k;return true}if(o){var v=b.E.substr(t,s-t);this.bw.HeadBlockContent=this.bw.HeadBlockContent+ay(v)+"\n";c.v=15;c.R=b.
-bK;c.contentEnd=b.bK;c.ay=b.bK;return true}c.v=15;c.N=b.by-c.R;return true}}else p++}return 0};a.M=function(b){var r=b[0
-].v,t=b[0].aq();for(var c=1;c<b.length;c++){if(b[c].v==12&&(b[c-1].v==12||b[c-1].v==11||b[c-1].v==10)){b[c-1].a3(b[c].ao
-());this.ai(b[c]);b.splice(c,1);c--;continue}if(b[c].v!=13&&b[c].v!=0){var s=b[c].aq();if(s>t){b[c].v=13;var v=b[c].ao()
-;b[c].R=b[c].ay+s;b[c].a3(v)}}}var h=this.T(0);h.v=r==11?21:20;h.C=[];for(var c=0;c<b.length;c++){var k=c;while(k>0&&b[k
--1].v==0)k--;var g=c;while(g<b.length-1&&b[g+1].v!=11&&b[g+1].v!=10)g++;if(k==g)h.C.push(this.T().V(b[c]));else{var o=
-false,n=this.bw.as();for(var e=k;e<=g;e++){var m=b[e];n.x(m.E.substr(m.R,m.N));n.x("\n");if(b[e].v==0)o=true}var j=this.
-T();j.v=19;j.ay=b[k].ay;var p=new D(this.bw);p.bx=r;j.C=p.aH(n.bh());if(!o)for(var e=0;e<j.C.length;e++){var q=j.C[e];
-if(q.v==12)q.v=17}h.C.push(j)}c=g}h.ay=h.C[0].ay;this.aj(b);b.length=0;return h};a.G=function(b){for(var c=1;c<b.length;
-c++)if(b[c].v==12&&(b[c-1].v==12||b[c-1].v==25)){b[c-1].a3(b[c].ao());this.ai(b[c]);b.splice(c,1);c--;continue}var k=b[0
-].X;if(b.length==1&&!k){var m=b[0];b.length=0;return m}var h=this.bw.as();for(var c=0;c<b.length;c++){var g=b[c];h.x(g.E
-.substr(g.R,g.N));h.x("\n")}var e=this.T(b[0].ay);e.v=25;var j=new D(this.bw);j.bx=25;e.C=j.aH(h.bh());this.aj(b);b.
-length=0;return e};a.I=function(e){var c=null;for(var b=0;b<e.length;b++)switch(e[b].v){case 26:case 25:if(c==null){c=
-this.T(e[b].ay);c.v=27;c.C=[];e.splice(b,0,c);b++}c.C.push(e[b]);e.splice(b,1);b--;break;default:c=null;break}};a.L=
-function(c){for(var b=1;b<c.length;b++)if(c[b].v==12&&(c[b-1].v==12||c[b-1].v==28)){c[b-1].a3(c[b].ao());this.ai(c[b]);c
-.splice(b,1);b--;continue}var h=this.bw.as();for(var b=0;b<c.length;b++){var g=c[b];h.x(g.E.substr(g.R,g.N));h.x("\n")}
-var j=new D(this.bw);j.bx=28;var e=this.T(c[0].ay);e.v=28;e.X=c[0].X;e.C=j.aH(h.bh());this.aj(c);c.length=0;return e};a.
-aJ=function(b,e){var m=b.by,k=b.H();b.az();while(b.H()==k)b.a5(1);var g=b.W();if(g.length<3)return false;b.a8();if(!b.Y(
-))return false;b.aZ();var j=b.by;if(!b.Z(g))return false;if(!Y(b.F(-1)))return false;var h=b.by;b.a5(g.length);b.a8();
-if(!b.Y())return false;e.v=18;e.C=[];h--;var c=this.T(m);c.v=13;c.E=b.E;c.R=j;c.N=h-j;e.C.push(c);return true};function 
-H(){this.bp=[];this.bu=null;this.bA=[]}a=H.prototype;a.ax=false;a.bk=false;a.aG=function(b){b.a8();if(b.Y())return null;
-var e=this.ax;if(this.ax&&!b.aW("|")){e=true;return null}var c=[];while(!b.Y()){b.az();while(!b.Y()&&b.H()!="|")b.a2(
-true);c.push(ay(b.W()));e|=b.aW("|")}if(!e)return null;while(c.length<this.bp.length)c.push("&nbsp;");b.aZ();return c};a
-.aT=function(h,b,e,g){for(var c=0;c<e.length;c++){b.x("\t<");b.x(g);if(c<this.bp.length)switch(this.bp[c]){case 1:b.x(
-' align="left"');break;case 2:b.x(' align="right"');break;case 3:b.x(' align="center"');break}b.x(">");h.bz.af(b,e[c]);b
-.x("</");b.x(g);b.x(">\n")}};a.l=function(e,b){b.x("<table>\n");if(this.bu!=null){b.x("<thead>\n<tr>\n");this.aT(e,b,
-this.bu,"th");b.x("</tr>\n</thead>\n")}b.x("<tbody>\n");for(var c=0;c<this.bA.length;c++){var g=this.bA[c];b.x("<tr>\n")
-;this.aT(e,b,g,"td");b.x("</tr>\n")}b.x("</tbody>\n");b.x("</table>\n")};function av(b){b.a8();if(b.H()!="|"&&b.H()!=":"
-&&b.H()!="-")return null;var c=null;if(b.aW("|")){c=new H();c.ax=true}while(true){b.a8();if(b.H()=="|")return null;var g
-=b.aW(":");while(b.H()=="-")b.a5(1);var h=b.aW(":");b.a8();var e=0;if(g&&h)e=3;else if(g)e=1;else if(h)e=2;if(b.Y()){if(
-c==null)return null;c.bp.push(e);return c}if(!b.aW("|"))return null;if(c==null)c=new H();c.bp.push(e);b.a8();if(b.Y()){c
-.bk=true;return c}}}this.Markdown=i;this.HtmlTag=w})();if(typeof exports!=="undefined")exports.Markdown=MarkdownDeep.
-Markdown;
+"<":var e=b.by,p=ag(b);if(p!=null)if((!this.bw.SafeMode||p.at())&&this.bw.AllowUserHtml)c=this.U(1,e,b.by-e);else b.by=e
+;else{b.by=e;c=this.aD();if(c==null)b.by=e}break;case"&":var e=b.by;if(b.a6())c=this.U(2,e,b.by-e);break;case" ":if(b.F(
+1)==" "&&Y(b.F(2))){b.a5(2);if(!b.J()){b.aZ();c=this.U(8,m,0)}}break;case"\\":if(U(b.F(1),q)){c=this.U(0,b.by+1,1);b.a5(
+2)}break}if(c==null&&k!=null&&!R(b.F(-1))){var v=b.by;for(var r in k){var n=k[r];if(b.a9(n.Abbr)&&!R(b.H())){c=this.O(15
+,n);break}b.bK=v}}if(c!=null){if(m>g)j.push(this.U(0,g,m-g));j.push(c);g=b.by}else b.a5(1)}if(b.by>g)j.push(this.U(0,g,b
+.by-g));if(h!=null)this.aV(j,h)};a.P=function(){var b=this.bB,e=b.H(),k=e=="*"?"_":"*",c=b.by;if(b.D()||ad(b.F(-1))){
+while(ae(b.H()))b.a5(1);if(b.J()||ad(b.H()))return this.U(2,c,b.by-c);b.by=c}while(ae(b.F(-1)))b.a5(-1);var h=b.D()||ad(
+b.F(-1));b.by=c;while(b.H()==e)b.a5(1);var j=b.by-c;while(ae(b.F(1)))b.a5(1);var g=b.J()||ad(b.H());b.by=c+j;if(h)
+return this.U(11,c,b.by-c);if(g)return this.U(12,c,b.by-c);if(this.bw.ExtraMode&&e=="_"&&R(b.H()))return null;
+return this.U(13,c,b.by-c)};a.bg=function(h,g,b,c){var e=this.U(b.type,b.startOffset+c,b.length-c);b.length=c;g.splice(S
+(g,b)+1,0,e);h.splice(S(h,b)+1,0,e);return e};a.aV=function(n,b){var m=this.bB.E,j=true;while(j){j=false;for(var h=0;h<b
+.length;h++){var c=b[h];if(c.type!=11&&c.type!=13)continue;for(var k=h+1;k<b.length;k++){var g=b[k];if(g.type!=12&&g.
+type!=13)break;if(m.charAt(c.startOffset)!=m.charAt(g.startOffset))continue;var e=Math.min(c.length,g.length);if(e>=3)e=
+e%2==1?1:2;if(c.length>e){c=this.bg(n,b,c,c.length-e);h--}if(g.length>e)this.bg(n,b,g,e);c.type=e==1?3:5;g.type=e==1?4:6
+;b.splice(S(b,c),1);b.splice(S(b,g),1);j=true;break}}}};a.aD=function(){if(this.br)return null;var c=this.bB;c.a5(1);c.
+az();var j=this.bw.ExtraMode;while(!c.J()){var h=c.H();if(ad(h))break;if(h==">"){var b=az(c.W(),j),e=null;if(ah(b)){var 
+g;if(b.toLowerCase().substr(0,7)=="mailto:")g=b.substr(7);else{g=b;b="mailto:"+b}e=new am(new C("auto",b,null),g)}else 
+if(al(b))e=new am(new C("auto",b,null),b);if(e!=null){c.a5(1);return this.O(9,e)}return null}c.a2(j)}return null};a.aI=
+function(){var b=this.bB,h=b.aW("!")?10:9;if(!b.aW("["))return null;var o=this.by;if(this.bw.ExtraMode&&h==9&&b.aW("^"))
+{b.a8();b.az();var m=b.a4();if(m!=null&&b.aW("]")){var s=this.bw.Q(m);if(s>=0)return this.O(14,{index:s,id:m})}this.by=o
+}if(this.br&&h==9)return null;var r=this.bw.ExtraMode;b.az();var j=1;while(!b.J()){var p=b.H();if(p=="[")j++;else if(p==
+"]"){j--;if(j==0)break}b.a2(r)}if(b.J())return null;var n=az(b.W(),r);b.a5(1);o=b.by;if(b.aW("(")){var t=ar(b,null,this.
+bw.ExtraMode);if(t==null)return null;b.bd();if(!b.aW(")"))return null;return this.O(h,new am(t,n))}if(!b.aW(" "))b.aW(
+"\t");if(b.Y()){b.aZ();b.a8()}var c=null;if(b.H()=="["){b.a5(1);b.az();if(!b.Z("]"))return null;c=b.W();b.a5(1)}else b.
+by=o;if(!c){c=n;while(true){var k=c.indexOf("\n");if(k<0)break;var g=k;while(g>0&&ad(c.charAt(g-1)))g--;var e=k;while(e<
+c.length&&ad(c.charAt(e)))e++;c=c.substr(0,g)+" "+c.substr(e)}}var q=this.bw.GetLinkDefinition(c);if(q==null)return null
+;return this.O(h,new am(q,n))};a.aF=function(){var b=this.bB,c=b.by,e=0;while(b.aW("`"))e++;b.bd();if(b.J())return this.
+U(0,c,b.by-c);var g=b.by;if(!b.Z(b.E.substr(c,e)))return this.U(0,c,b.by-c);var h=b.by+e;while(ad(b.F(-1)))b.a5(-1);var 
+j=this.U(7,g,b.by-g);b.by=h;return j};a.U=function(g,e,c){if(this.bG.length!=0){var b=this.bG.pop();b.type=g;b.
+startOffset=e;b.length=c;b.X=null;return b}else return new ax(g,e,c)};a.O=function(e,c){if(this.bG.length!=0){var b=this
+.bG.pop();b.type=e;b.X=c;return b}else{var b=new ax(e,0,0);b.X=c;return b}};a.ak=function(b){b.X=null;this.bG.push(b)};
+function B(){}a=B.prototype;a.E=null;a.v=0;a.R=0;a.N=0;a.ay=0;a.aA=0;a.C=null;a.X=null;a.an=function(){if(this.E==null)
+return null;if(this.R==-1)return this.E;return this.E.substr(this.R,this.N)};a.al=function(){var c=new F();for(var b=0;b
+<this.C.length;b++){c.x(this.C[b].an());c.x("\n")}return c.bh()};a.aN=function(e,c){for(var b=0;b<this.C.length;b++)this
+.C[b].l(e,c)};a.aX=function(e){if(typeof this.X=="string")return this.X;var c=at(this.E,this.R,this.ao()),b=null;if(c!=
+null){this.a3(c.end);b=c.id}else b=e.aC(this.E,this.R,this.N);this.X=b;return b};a.l=function(c,b){switch(this.v){case 0
+:return;case 12:c.bz.ah(b,this.E,this.R,this.N);break;case 17:c.bz.ae(b,this.E,this.R,this.N);b.x("\n");break;case 1:
+case 2:case 3:case 4:case 5:case 6:if(c.ExtraMode&&!c.SafeMode){b.x("<h"+(this.v-1+1).toString());var k=this.aX(c);if(k)
+{b.x(' id="');b.x(k);b.x('">')}else b.x(">")}else b.x("<h"+(this.v-1+1).toString()+">");c.bz.ae(b,this.E,this.R,this.N);
+b.x("</h"+(this.v-1+1).toString()+">\n");break;case 14:b.x("<hr />\n");return;case 10:case 11:b.x("<li>");c.bz.ae(b,this
+.E,this.R,this.N);b.x("</li>\n");break;case 15:b.x(this.E.substr(this.R,this.N));return;case 16:b.au(this.E,this.R,this.
+N);return;case 18:b.x("<pre");if(c.FormatCodeBlockAttributes!=null)b.x(c.FormatCodeBlockAttributes(this.X));b.x(
+"><code>");var h=b;if(c.FormatCodeBlock){h=b;b=new F()}for(var e=0;e<this.C.length;e++){var j=this.C[e];b.av(j.E,j.R,j.N
+);b.x("\n")}if(c.FormatCodeBlock){h.x(c.FormatCodeBlock(b.bh(),this.X));b=h}b.x("</code></pre>\n\n");return;case 9:b.x(
+"<blockquote>\n");this.aN(c,b);b.x("</blockquote>\n");return;case 19:b.x("<li>\n");this.aN(c,b);b.x("</li>\n");return;
+case 20:b.x("<ol>\n");this.aN(c,b);b.x("</ol>\n");return;case 21:b.x("<ul>\n");this.aN(c,b);b.x("</ul>\n");return;case 
+22:var g=this.X,n=g.name.toLowerCase();if(n=="a")c.OnPrepareLink(g);else if(n=="img")c.OnPrepareImage(g,c.
+RenderingTitledImage);g.aS(b);b.x("\n");this.aN(c,b);g.aO(b);b.x("\n");return;case 23:case 28:this.aN(c,b);return;case 
+24:this.X.l(c,b);return;case 25:b.x("<dd>");if(this.C!=null){b.x("\n");this.aN(c,b)}else c.bz.ae(b,this.E,this.R,this.N)
+;b.x("</dd>\n");break;case 26:if(this.C==null){var m=this.an().split("\n");for(var e=0;e<m.length;e++){var o=m[e];b.x(
+"<dt>");c.bz.af(b,ay(o));b.x("</dt>\n")}}else{b.x("<dt>\n");this.aN(c,b);b.x("</dt>\n")}break;case 27:b.x("<dl>\n");this
+.aN(c,b);b.x("</dl>\n");return;case 29:b.x("<p>");if(this.N>0){c.bz.ae(b,this.E,this.R,this.N);b.x("&nbsp;")}b.x(this.X)
+;b.x("</p>\n");break}};a.aY=function(){this.v=12;this.R=this.ay;this.N=this.aA};a.ao=function(){return this.R+this.N};a.
+a3=function(b){this.N=b-this.R};a.aq=function(){var c=0;for(var b=this.ay;b<this.ay+this.aA;b++)if(this.E.charAt(b)==" "
+)c++;else break;return c};a.V=function(b){this.v=b.v;this.E=b.E;this.R=b.R;this.N=b.N;this.ay=b.ay;this.aA=b.aA;
+return this};function D(b,c){this.bw=b;this.bx=0;this.bo=c}a=D.prototype;a.aH=function(c){var b=new G(c);return this.a1(
+b)};a.aL=function(g,e,b){var c=new G(g,e,b);return this.a1(c)};a.bi=function(b,c,e){if(e.length>1)return false;if(e.
+length==1){var g=b.by;b.by=e[0].ay;c.bu=c.aG(b);if(c.bu==null)return false;b.by=g;e.length=0}while(true){var g=b.by,h=c.
+aG(b);if(h!=null){c.bA.push(h);continue}b.by=g;break}return true};a.a1=function(j){var e=[],c=[],k=-1;while(!j.J()){var 
+m=k==0,b=this.ab(j);k=b.v;if(b.v==25)b.X=m;if(b.v==7||b.v==8){if(c.length>0){var g=c.pop();this.S(e,c);if(g.v!=0){g.aY()
+;g.v=b.v==7?1:2;e.push(g);continue}}if(b.v==7){b.aY();c.push(b)}else if(b.N>=3){b.v=14;e.push(b)}else{b.aY();c.push(b)}
+continue}var h=c.length>0?c[0].v:0;if(b.v==24){var o=b.X,n=j.by;if(!this.bi(j,o,c)){j.by=n;b.aY()}else{e.push(b);
+continue}}switch(b.v){case 0:switch(h){case 0:this.ai(b);break;case 12:this.S(e,c);this.ai(b);break;case 9:case 10:case 
+11:case 25:case 28:case 13:c.push(b);break}break;case 12:switch(h){case 0:case 12:c.push(b);break;case 9:case 10:case 11
+:case 25:case 28:var g=c[c.length-1];if(g.v==0){this.S(e,c);c.push(b)}else c.push(b);break;case 13:this.S(e,c);c.push(b)
+;break}break;case 13:switch(h){case 0:c.push(b);break;case 12:case 9:var g=c[c.length-1];if(g.v==0){this.S(e,c);c.push(b
+)}else{b.aY();c.push(b)}break;case 10:case 11:case 13:case 25:case 28:c.push(b);break}break;case 9:if(h!=9)this.S(e,c);c
+.push(b);break;case 10:case 11:switch(h){case 0:c.push(b);break;case 12:case 9:var g=c[c.length-1];if(g.v==0||this.bx==
+10||this.bx==11||this.bx==25){this.S(e,c);c.push(b)}else{b.aY();c.push(b)}break;case 10:case 11:if(b.v!=10&&b.v!=11)this
+.S(e,c);c.push(b);break;case 25:case 28:if(b.v!=h)this.S(e,c);c.push(b);break;case 13:this.S(e,c);c.push(b);break}break;
+case 25:case 28:switch(h){case 0:case 12:case 25:case 28:this.S(e,c);c.push(b);break;default:b.aY();c.push(b);break}
+break;default:this.S(e,c);e.push(b);break}}this.S(e,c);if(this.bw.ExtraMode)this.I(e);return e};a.T=function(c){var b;
+if(this.bw.bC.length>1)b=this.bw.bC.pop();else b=new B();b.ay=c;return b};a.ai=function(b){this.bw.bC.push(b)};a.aj=
+function(b){for(var c=0;c<b.length;c++)this.bw.bC.push(b[c]);b.length=0};a.aQ=function(g){var b=this.bw.as();for(var c=0
+;c<g.length;c++){var e=g[c];b.x(e.E.substr(e.R,e.N));b.x("\n")}return b.bh()};a.S=function(c,b){while(b.length>0&&b[b.
+length-1].v==0)this.ai(b.pop());if(b.length==0)return;switch(b[0].v){case 12:var h=this.T(b[0].ay);h.v=12;h.E=b[0].E;h.R
+=b[0].R;h.a3(b[b.length-1].ao());c.push(h);this.aj(b);break;case 9:var p=this.aQ(b),o=new D(this.bw,this.bo);o.bx=9;var 
+n=this.T(b[0].ay);n.v=9;n.C=o.aH(p);this.aj(b);c.push(n);break;case 10:case 11:c.push(this.M(b));break;case 25:if(c.
+length>0){var j=c[c.length-1];switch(j.v){case 12:j.v=26;break;case 25:break;default:var k=this.T(j.ay);k.v=26;k.C=[];k.
+C.push(j);c.pop();c.push(k);break}}c.push(this.G(b));break;case 28:this.bw.z(this.L(b));break;case 13:var e=this.T(b[0].
+ay);e.v=18;e.C=[];var g=b[0].an();if(g.substr(0,2)=="{{"&&g.substr(g.length-2,2)=="}}"){e.X=g.substr(2,g.length-4);b.
+splice(0,1)}for(var m=0;m<b.length;m++)e.C.push(b[m]);c.push(e);b.length=0;break}};a.ab=function(c){var b=this.T(c.by);b
+.E=c.E;b.R=c.by;b.N=-1;b.v=this.ac(c,b);if(b.N<0){c.bb();b.N=c.by-b.R}b.aA=c.by-b.ay;c.aZ();return b};a.ac=function(b,c)
+{if(b.Y())return 0;var h=b.by,e=b.H();if(e=="#"){var j=1;b.a5(1);while(b.H()=="#"){j++;b.a5(1)}if(j>6)j=6;b.a8();c.R=b.
+by;b.bb();if(this.bw.ExtraMode&&!this.bw.SafeMode){var m=at(b.E,c.R,b.by);if(m!=null){c.X=m.id;b.by=m.end}}while(b.by>c.
+R&&b.F(-1)=="#")b.a5(-1);while(b.by>c.R&&ad(b.F(-1)))b.a5(-1);c.N=b.by-c.R;b.bb();return 1+j-1}if(e=="-"||e=="="){var k=
+e;while(b.H()==k)b.a5(1);b.a8();if(b.Y())return k=="="?7:8;b.by=h}if(this.bw.ExtraMode){var s=av(b);if(s!=null){c.X=s;
+return 24}b.by=h;if(e=="~"||e=="`"){if(this.aJ(b,c))return c.v;b.by=h}}var g=-1,r=0;while(!b.Y()){if(b.H()==" "){if(g<0)
+r++}else if(b.H()=="\t"){if(g<0)g=b.by}else break;b.a5(1)}if(b.Y()){c.N=0;return 0}if(r>=4){c.R=h+4;return 13}if(g>=0&&g
+-h<4){c.R=g+1;return 13}c.R=b.by;e=b.H();if(e=="<"){if(this.a0(b,c))return c.v;b.by=c.R}if(e==">"){if(ab(b.F(1))){b.a5(2
+);c.R=b.by;return 9}b.a5(1);c.R=b.by;return 9}if(e=="-"||e=="_"||e=="*"){var o=0;while(!b.Y()){var k=b.H();if(b.H()==e){
+o++;b.a5(1);continue}if(ab(b.H())){b.a5(1);continue}break}if(b.Y()&&o>=3)return 14;b.by=c.R}if(this.bw.ExtraMode&&e=="*"
+&&b.F(1)=="["){b.a5(2);b.a8();b.az();while(!b.Y()&&b.H()!="]")b.a5(1);var n=ay(b.W());if(b.H()=="]"&&b.F(1)==":"&&n){b.
+a5(2);b.a8();b.az();b.bb();var v=b.W();this.bw.y(n,v);return 0}b.by=c.R}if((e=="*"||e=="+"||e=="-")&&ab(b.F(1))){b.a5(1)
+;b.a8();c.R=b.by;return 11}if(e==":"&&this.bw.ExtraMode&&ab(b.F(1))){b.a5(1);b.a8();c.R=b.by;return 25}if(X(e)){b.a5(1);
+while(X(b.H()))b.a5(1);if(b.aW(".")&&b.a8()){c.R=b.by;return 10}b.by=c.R}if(e=="["){if(this.bw.ExtraMode&&b.F(1)=="^"){
+var t=b.by;b.a5(2);var p=b.a4();if(p!=null&&b.aW("]")&&b.aW(":")){b.a8();c.R=b.by;c.X=p;return 28}b.by=t}var q=an(b,this
+.bw.ExtraMode);if(q!=null){this.bw.A(q);return 0}}return 12};a.ar=function(c){var b=c.attributes.markdown;if(b==
+undefined)if(this.bo)return 3;else return 0;delete c.attributes.markdown;if(b=="1")return(c.ap()&8)!=0?2:1;if(b=="block"
+)return 1;if(b=="deep")return 3;if(b=="span")return 2;return 4};a.aK=function(b,e,o,m){var g=b.by,k=1,j=false;while(!b.J
+()){if(!b.Z("<"))break;var n=b.by,h=ag(b);if(h==null){b.a5(1);continue}if(this.bw.SafeMode&&m==4&&!j)if(!h.at())j=true;
+if(h.closed)continue;if(h.name==o.name)if(h.closing){k--;if(k==0){b.a8();b.aZ();e.v=22;e.X=o;e.a3(b.by);switch(m){case 2
+:var c=this.T(g);c.E=b.E;c.v=17;c.R=g;c.N=n-g;e.C=[];e.C.push(c);break;case 1:case 3:var p=new D(this.bw,m==3);e.C=p.aL(
+b.E,g,n-g);break;case 4:if(j){e.v=16;e.a3(b.by)}else{var c=this.T(g);c.E=b.E;c.v=15;c.R=g;c.N=n-g;e.C=[];e.C.push(c)}
+break}return true}}else k++}return false};a.a0=function(b,c){var g=b.by,h=ag(b);if(h==null)return false;if(h.closing)
+return false;var m=false;if(this.bw.SafeMode&&!h.at()||!this.bw.AllowUserHtml)m=true;var q=h.ap();if((q&1)==0)
+return false;if((q&4)!=0||h.closed){b.a8();b.aZ();c.N=b.by-c.R;c.v=m?16:15;return true}if((q&2)!=0){b.a8();if(!b.Y())
+return false}var o=this.bw.ExtractHeadBlocks&&h.name.toLowerCase()=="head",t=b.by;if(!o&&this.bw.ExtraMode){var n=this.
+ar(h);if(n!=0)return this.aK(b,c,h,n)}var k=null,p=1;while(!b.J()){if(!b.Z("<"))break;var s=b.by,j=ag(b);if(j==null){b.
+a5(1);continue}if(this.bw.SafeMode&&!j.at())m=true;if(j.closed)continue;if(!o&&!j.closing&&this.bw.ExtraMode&&!m){var n=
+this.ar(j);if(n!=0){var r=this.T(g);if(this.aK(b,r,j,n)){if(k==null)k=[];if(s>g){var e=this.T(g);e.E=b.E;e.v=15;e.R=g;e.
+N=s-g;k.push(e)}k.push(r);g=b.by;continue}else this.ai(r)}}if(j.name==h.name&&!j.closed)if(j.closing){p--;if(p==0){b.a8(
+);b.aZ();if(m){c.v=16;c.a3(b.by);return true}if(k!=null){if(b.by>g){var e=this.T(g);e.E=b.E;e.v=15;e.R=g;e.N=b.by-g;k.
+push(e)}c.v=23;c.a3(b.by);c.C=k;return true}if(o){var v=b.E.substr(t,s-t);this.bw.HeadBlockContent=this.bw.
+HeadBlockContent+ay(v)+"\n";c.v=15;c.R=b.bK;c.contentEnd=b.bK;c.ay=b.bK;return true}c.v=15;c.N=b.by-c.R;return true}}
+else p++}return 0};a.M=function(b){var r=b[0].v,t=b[0].aq();for(var c=1;c<b.length;c++){if(b[c].v==12&&(b[c-1].v==12||b[
+c-1].v==11||b[c-1].v==10)){b[c-1].a3(b[c].ao());this.ai(b[c]);b.splice(c,1);c--;continue}if(b[c].v!=13&&b[c].v!=0){var s
+=b[c].aq();if(s>t){b[c].v=13;var v=b[c].ao();b[c].R=b[c].ay+s;b[c].a3(v)}}}var h=this.T(0);h.v=r==11?21:20;h.C=[];for(
+var c=0;c<b.length;c++){var k=c;while(k>0&&b[k-1].v==0)k--;var g=c;while(g<b.length-1&&b[g+1].v!=11&&b[g+1].v!=10)g++;
+if(k==g)h.C.push(this.T().V(b[c]));else{var o=false,n=this.bw.as();for(var e=k;e<=g;e++){var m=b[e];n.x(m.E.substr(m.R,m
+.N));n.x("\n");if(b[e].v==0)o=true}var j=this.T();j.v=19;j.ay=b[k].ay;var p=new D(this.bw);p.bx=r;j.C=p.aH(n.bh());if(!o
+)for(var e=0;e<j.C.length;e++){var q=j.C[e];if(q.v==12)q.v=17}h.C.push(j)}c=g}h.ay=h.C[0].ay;this.aj(b);b.length=0;
+return h};a.G=function(b){for(var c=1;c<b.length;c++)if(b[c].v==12&&(b[c-1].v==12||b[c-1].v==25)){b[c-1].a3(b[c].ao());
+this.ai(b[c]);b.splice(c,1);c--;continue}var k=b[0].X;if(b.length==1&&!k){var m=b[0];b.length=0;return m}var h=this.bw.
+as();for(var c=0;c<b.length;c++){var g=b[c];h.x(g.E.substr(g.R,g.N));h.x("\n")}var e=this.T(b[0].ay);e.v=25;var j=new D(
+this.bw);j.bx=25;e.C=j.aH(h.bh());this.aj(b);b.length=0;return e};a.I=function(e){var c=null;for(var b=0;b<e.length;b++)
+switch(e[b].v){case 26:case 25:if(c==null){c=this.T(e[b].ay);c.v=27;c.C=[];e.splice(b,0,c);b++}c.C.push(e[b]);e.splice(b
+,1);b--;break;default:c=null;break}};a.L=function(c){for(var b=1;b<c.length;b++)if(c[b].v==12&&(c[b-1].v==12||c[b-1].v==
+28)){c[b-1].a3(c[b].ao());this.ai(c[b]);c.splice(b,1);b--;continue}var h=this.bw.as();for(var b=0;b<c.length;b++){var g=
+c[b];h.x(g.E.substr(g.R,g.N));h.x("\n")}var j=new D(this.bw);j.bx=28;var e=this.T(c[0].ay);e.v=28;e.X=c[0].X;e.C=j.aH(h.
+bh());this.aj(c);c.length=0;return e};a.aJ=function(b,e){var m=b.by,k=b.H();b.az();while(b.H()==k)b.a5(1);var g=b.W();
+if(g.length<3)return false;b.a8();if(!b.Y())return false;b.aZ();var j=b.by;if(!b.Z(g))return false;if(!Y(b.F(-1)))
+return false;var h=b.by;b.a5(g.length);b.a8();if(!b.Y())return false;e.v=18;e.C=[];h--;var c=this.T(m);c.v=13;c.E=b.E;c.
+R=j;c.N=h-j;e.C.push(c);return true};function H(){this.bp=[];this.bu=null;this.bA=[]}a=H.prototype;a.ax=false;a.bk=false
+;a.aG=function(b){b.a8();if(b.Y())return null;var e=this.ax;if(this.ax&&!b.aW("|")){e=true;return null}var c=[];while(!b
+.Y()){b.az();while(!b.Y()&&b.H()!="|")b.a2(true);c.push(ay(b.W()));e|=b.aW("|")}if(!e)return null;while(c.length<this.bp
+.length)c.push("&nbsp;");b.aZ();return c};a.aT=function(h,b,e,g){for(var c=0;c<e.length;c++){b.x("\t<");b.x(g);if(c<this
+.bp.length)switch(this.bp[c]){case 1:b.x(' align="left"');break;case 2:b.x(' align="right"');break;case 3:b.x(
+' align="center"');break}b.x(">");h.bz.af(b,e[c]);b.x("</");b.x(g);b.x(">\n")}};a.l=function(e,b){b.x("<table>\n");if(
+this.bu!=null){b.x("<thead>\n<tr>\n");this.aT(e,b,this.bu,"th");b.x("</tr>\n</thead>\n")}b.x("<tbody>\n");for(var c=0;c<
+this.bA.length;c++){var g=this.bA[c];b.x("<tr>\n");this.aT(e,b,g,"td");b.x("</tr>\n")}b.x("</tbody>\n");b.x("</table>\n"
+)};function av(b){b.a8();if(b.H()!="|"&&b.H()!=":"&&b.H()!="-")return null;var c=null;if(b.aW("|")){c=new H();c.ax=true}
+while(true){b.a8();if(b.H()=="|")return null;var g=b.aW(":");while(b.H()=="-")b.a5(1);var h=b.aW(":");b.a8();var e=0;if(
+g&&h)e=3;else if(g)e=1;else if(h)e=2;if(b.Y()){if(c==null)return null;c.bp.push(e);return c}if(!b.aW("|"))return null;
+if(c==null)c=new H();c.bp.push(e);b.a8();if(b.Y()){c.bk=true;return c}}}this.Markdown=i;this.HtmlTag=w})();if(typeof 
+exports!=="undefined")exports.Markdown=MarkdownDeep.Markdown;
 // MarkdownDeep - http://www.toptensoftware.com/markdowndeep
 // Copyright (C) 2010-2011 Topten Software
 var MarkdownDeepEditor=new(function(){var q=false,w={Z:"undo",Y:"redo",B:"bold",I:"italic",H:"heading",K:"code",U:

--- a/MarkdownDeepTests/JSTestResources/MarkdownDeep.js
+++ b/MarkdownDeepTests/JSTestResources/MarkdownDeep.js
@@ -59,7 +59,8 @@ var MarkdownDeep = new function () {
         FormatCodeBlockAttributes: null,
         FormatCodeBlock: null,
         ExtractHeadBlocks: false,
-        HeadBlockContent: ""
+        HeadBlockContent: "",
+        AllowUserHtml: true
     };
 
     var p = Markdown.prototype;
@@ -2017,7 +2018,7 @@ var MarkdownDeep = new function () {
                     var tag = ParseHtmlTag(p);
                     if (tag != null) {
                         // Yes, create a token for it
-                        if (!this.m_Markdown.SafeMode || tag.IsSafe()) {
+                        if ((!this.m_Markdown.SafeMode || tag.IsSafe()) && this.m_Markdown.AllowUserHtml) {
                             // Yes, create a token for it
                             token = this.CreateToken(TokenType_HtmlTag, save, p.m_position - save);
                         }
@@ -3760,7 +3761,7 @@ var MarkdownDeep = new function () {
 
         // Safe mode?
         var bHasUnsafeContent = false;
-        if (this.m_Markdown.SafeMode && !openingTag.IsSafe())
+        if ((this.m_Markdown.SafeMode && !openingTag.IsSafe()) || !this.m_Markdown.AllowUserHtml)
             bHasUnsafeContent = true;
 
         var flags = openingTag.get_Flags();

--- a/MarkdownDeepTests/JSTestResources/MarkdownDeep.min.js
+++ b/MarkdownDeepTests/JSTestResources/MarkdownDeep.min.js
@@ -6,27 +6,27 @@ if(b[c]===e)return c;return-1}function i(){this.bz=new E(this);this.bC=[];this.b
 SafeMode:false,ExtraMode:false,MarkdownInHtml:false,AutoHeadingIDs:false,UrlBaseLocation:null,UrlRootLocation:null,
 NewWindowForExternalLinks:false,NewWindowForLocalLinks:false,NoFollowLinks:false,NoFollowExternalLinks:false,
 HtmlClassFootnotes:"footnotes",HtmlClassTitledImages:null,RenderingTitledImage:false,FormatCodeBlockAttributes:null,
-FormatCodeBlock:null,ExtractHeadBlocks:false,HeadBlockContent:""};var a=i.prototype;function ao(b,c,e,g){return b.slice(
-0,c).concat(g).concat(b.slice(c+e))}i.prototype.GetListItems=function(k,n){var c=this.aE(k),b;for(b=0;b<c.length;b++){
-var e=c[b];if((e.v==23||e.v==15||e.v==22)&&e.C){c=ao(c,b,1,e.C);b--;continue}if(n<e.ay)break}b--;if(b<0)return null;var 
-h=c[b];if(h.v!=21&&h.v!=20)return null;var g=[],m=h.C;for(var j=0;j<m.length;j++)g.push(m[j].ay);b++;if(b<c.length)g.
-push(c[b].ay);else g.push(k.length);return g};i.prototype.Transform=function(c){var n=c.indexOf("\r");if(n>=0){var m=c.
-indexOf("\n");if(m>=0)if(m<n)c=c.replace(/\n\r/g,"\n");else c=c.replace(/\r\n/g,"\n");c=c.replace(/\r/g,"\n")}this.
-HeadBlockContent="";var k=this.aE(c);if(this.bn!=null){var j=[];for(var r in this.bn)j.push(this.bn[r]);j.sort(function(
-p,q){return q.Abbr.length-p.Abbr.length});this.bn=j}var b=this.bF;b.K();for(var g=0;g<k.length;g++){var s=k[g];s.l(this,
-b)}if(this.bI.length>0){b.x('\n<div class="');b.x(this.HtmlClassFootnotes);b.x('">\n');b.x("<hr />\n");b.x("<ol>\n");
-for(var g=0;g<this.bI.length;g++){var h=this.bI[g];b.x('<li id="fn:');b.x(h.X);b.x('">\n');var o='<a href="#fnref:'+h.X+
-'" rev="footnote">&#8617;</a>',e=h.C[h.C.length-1];if(e.v==12){e.v=29;e.X=o}else{e=new B();e.N=0;e.v=29;e.X=o;h.C.push(e
-)}h.l(this,b);b.x("</li>\n")}b.x("</ol>\n");b.x("</div>\n")}return b.bh()};i.prototype.OnQualifyUrl=function(b){if(au(b,
-"#"))return b;if(aj(b))return b;if(au(b,"/")){var e=this.UrlRootLocation;if(!e){if(!this.UrlBaseLocation)return b;var c=
-this.UrlBaseLocation.indexOf("://");if(c==-1)c=0;else c+=3;c=this.UrlBaseLocation.indexOf("/",c);e=c<0?this.
-UrlBaseLocation:this.UrlBaseLocation.substr(0,c)}return e+b}else{if(!this.UrlBaseLocation)return b;if(!T(this.
-UrlBaseLocation,"/"))return this.UrlBaseLocation+"/"+b;else return this.UrlBaseLocation+b}};i.prototype.OnGetImageSize=
-function(b,c){return null};i.prototype.OnPrepareLink=function(b){var c=b.attributes.href;if(this.NoFollowLinks)b.
-attributes.rel="nofollow";if(this.NoFollowExternalLinks)if(aj(c))b.attributes.rel="nofollow";if(this.
-NewWindowForExternalLinks&&aj(c)||this.NewWindowForLocalLinks&&!aj(c))b.attributes.target="_blank";b.attributes.href=
-this.OnQualifyUrl(c)};i.prototype.OnPrepareImage=function(b,e){var c=this.OnGetImageSize(b.attributes.src,e);if(c!=null)
-{b.attributes.width=c.width;b.attributes.height=c.height}b.attributes.src=this.OnQualifyUrl(b.attributes.src)};i.
+FormatCodeBlock:null,ExtractHeadBlocks:false,HeadBlockContent:"",AllowUserHtml:true};var a=i.prototype;function ao(b,c,e
+,g){return b.slice(0,c).concat(g).concat(b.slice(c+e))}i.prototype.GetListItems=function(k,n){var c=this.aE(k),b;for(b=0
+;b<c.length;b++){var e=c[b];if((e.v==23||e.v==15||e.v==22)&&e.C){c=ao(c,b,1,e.C);b--;continue}if(n<e.ay)break}b--;if(b<0
+)return null;var h=c[b];if(h.v!=21&&h.v!=20)return null;var g=[],m=h.C;for(var j=0;j<m.length;j++)g.push(m[j].ay);b++;
+if(b<c.length)g.push(c[b].ay);else g.push(k.length);return g};i.prototype.Transform=function(c){var n=c.indexOf("\r");
+if(n>=0){var m=c.indexOf("\n");if(m>=0)if(m<n)c=c.replace(/\n\r/g,"\n");else c=c.replace(/\r\n/g,"\n");c=c.replace(/\r/g
+,"\n")}this.HeadBlockContent="";var k=this.aE(c);if(this.bn!=null){var j=[];for(var r in this.bn)j.push(this.bn[r]);j.
+sort(function(p,q){return q.Abbr.length-p.Abbr.length});this.bn=j}var b=this.bF;b.K();for(var g=0;g<k.length;g++){var s=
+k[g];s.l(this,b)}if(this.bI.length>0){b.x('\n<div class="');b.x(this.HtmlClassFootnotes);b.x('">\n');b.x("<hr />\n");b.x
+("<ol>\n");for(var g=0;g<this.bI.length;g++){var h=this.bI[g];b.x('<li id="fn:');b.x(h.X);b.x('">\n');var o=
+'<a href="#fnref:'+h.X+'" rev="footnote">&#8617;</a>',e=h.C[h.C.length-1];if(e.v==12){e.v=29;e.X=o}else{e=new B();e.N=0;
+e.v=29;e.X=o;h.C.push(e)}h.l(this,b);b.x("</li>\n")}b.x("</ol>\n");b.x("</div>\n")}return b.bh()};i.prototype.
+OnQualifyUrl=function(b){if(au(b,"#"))return b;if(aj(b))return b;if(au(b,"/")){var e=this.UrlRootLocation;if(!e){if(!
+this.UrlBaseLocation)return b;var c=this.UrlBaseLocation.indexOf("://");if(c==-1)c=0;else c+=3;c=this.UrlBaseLocation.
+indexOf("/",c);e=c<0?this.UrlBaseLocation:this.UrlBaseLocation.substr(0,c)}return e+b}else{if(!this.UrlBaseLocation)
+return b;if(!T(this.UrlBaseLocation,"/"))return this.UrlBaseLocation+"/"+b;else return this.UrlBaseLocation+b}};i.
+prototype.OnGetImageSize=function(b,c){return null};i.prototype.OnPrepareLink=function(b){var c=b.attributes.href;if(
+this.NoFollowLinks)b.attributes.rel="nofollow";if(this.NoFollowExternalLinks)if(aj(c))b.attributes.rel="nofollow";if(
+this.NewWindowForExternalLinks&&aj(c)||this.NewWindowForLocalLinks&&!aj(c))b.attributes.target="_blank";b.attributes.
+href=this.OnQualifyUrl(c)};i.prototype.OnPrepareImage=function(b,e){var c=this.OnGetImageSize(b.attributes.src,e);if(c!=
+null){b.attributes.width=c.width;b.attributes.height=c.height}b.attributes.src=this.OnQualifyUrl(b.attributes.src)};i.
 prototype.GetLinkDefinition=function(b){if(this.bv.hasOwnProperty(b))return this.bv[b];else return null};a.aE=function(b
 ){this.bv=[];this.bs=[];this.bI=[];this.bJ=[];this.bn=null;return new D(this,this.MarkdownInHtml).aH(b)};a.A=function(b)
 {this.bv[b.id]=b};a.z=function(b){this.bs[b.X]=b};a.Q=function(c){var b=this.bs[c];if(b!=undefined){this.bI.push(b);
@@ -150,149 +150,149 @@ b.x("<abbr");if(e.Title){b.x(' title="');b.au(e.Title,0,e.Title.length);b.x('"')
 this.bw.am(),o=k==null?/[\*\_\`\[\!\<\&\ \\]/g:null,q=this.bw.ExtraMode,g=b.by;while(!b.J()){if(o!=null&&!b.aa(o))break;
 var m=b.by,c=null;switch(b.H()){case"*":case"_":c=this.P();if(c!=null)switch(c.type){case 13:case 11:case 12:if(h==null)
 h=[];h.push(c);break}break;case"`":c=this.aF();break;case"[":case"!":var t=b.by;c=this.aI();if(c==null)b.by=t;break;case
-"<":var e=b.by,p=ag(b);if(p!=null)if(!this.bw.SafeMode||p.at())c=this.U(1,e,b.by-e);else b.by=e;else{b.by=e;c=this.aD();
-if(c==null)b.by=e}break;case"&":var e=b.by;if(b.a6())c=this.U(2,e,b.by-e);break;case" ":if(b.F(1)==" "&&Y(b.F(2))){b.a5(
-2);if(!b.J()){b.aZ();c=this.U(8,m,0)}}break;case"\\":if(U(b.F(1),q)){c=this.U(0,b.by+1,1);b.a5(2)}break}if(c==null&&k!=
-null&&!R(b.F(-1))){var v=b.by;for(var r in k){var n=k[r];if(b.a9(n.Abbr)&&!R(b.H())){c=this.O(15,n);break}b.bK=v}}if(c!=
-null){if(m>g)j.push(this.U(0,g,m-g));j.push(c);g=b.by}else b.a5(1)}if(b.by>g)j.push(this.U(0,g,b.by-g));if(h!=null)this.
-aV(j,h)};a.P=function(){var b=this.bB,e=b.H(),k=e=="*"?"_":"*",c=b.by;if(b.D()||ad(b.F(-1))){while(ae(b.H()))b.a5(1);if(
-b.J()||ad(b.H()))return this.U(2,c,b.by-c);b.by=c}while(ae(b.F(-1)))b.a5(-1);var h=b.D()||ad(b.F(-1));b.by=c;while(b.H()
-==e)b.a5(1);var j=b.by-c;while(ae(b.F(1)))b.a5(1);var g=b.J()||ad(b.H());b.by=c+j;if(h)return this.U(11,c,b.by-c);if(g)
-return this.U(12,c,b.by-c);if(this.bw.ExtraMode&&e=="_"&&R(b.H()))return null;return this.U(13,c,b.by-c)};a.bg=function(
-h,g,b,c){var e=this.U(b.type,b.startOffset+c,b.length-c);b.length=c;g.splice(S(g,b)+1,0,e);h.splice(S(h,b)+1,0,e);
-return e};a.aV=function(n,b){var m=this.bB.E,j=true;while(j){j=false;for(var h=0;h<b.length;h++){var c=b[h];if(c.type!=
-11&&c.type!=13)continue;for(var k=h+1;k<b.length;k++){var g=b[k];if(g.type!=12&&g.type!=13)break;if(m.charAt(c.
-startOffset)!=m.charAt(g.startOffset))continue;var e=Math.min(c.length,g.length);if(e>=3)e=e%2==1?1:2;if(c.length>e){c=
-this.bg(n,b,c,c.length-e);h--}if(g.length>e)this.bg(n,b,g,e);c.type=e==1?3:5;g.type=e==1?4:6;b.splice(S(b,c),1);b.splice
-(S(b,g),1);j=true;break}}}};a.aD=function(){if(this.br)return null;var c=this.bB;c.a5(1);c.az();var j=this.bw.ExtraMode;
-while(!c.J()){var h=c.H();if(ad(h))break;if(h==">"){var b=az(c.W(),j),e=null;if(ah(b)){var g;if(b.toLowerCase().substr(0
-,7)=="mailto:")g=b.substr(7);else{g=b;b="mailto:"+b}e=new am(new C("auto",b,null),g)}else if(al(b))e=new am(new C("auto"
-,b,null),b);if(e!=null){c.a5(1);return this.O(9,e)}return null}c.a2(j)}return null};a.aI=function(){var b=this.bB,h=b.aW
-("!")?10:9;if(!b.aW("["))return null;var o=this.by;if(this.bw.ExtraMode&&h==9&&b.aW("^")){b.a8();b.az();var m=b.a4();if(
-m!=null&&b.aW("]")){var s=this.bw.Q(m);if(s>=0)return this.O(14,{index:s,id:m})}this.by=o}if(this.br&&h==9)return null;
-var r=this.bw.ExtraMode;b.az();var j=1;while(!b.J()){var p=b.H();if(p=="[")j++;else if(p=="]"){j--;if(j==0)break}b.a2(r)
-}if(b.J())return null;var n=az(b.W(),r);b.a5(1);o=b.by;if(b.aW("(")){var t=ar(b,null,this.bw.ExtraMode);if(t==null)
-return null;b.bd();if(!b.aW(")"))return null;return this.O(h,new am(t,n))}if(!b.aW(" "))b.aW("\t");if(b.Y()){b.aZ();b.a8
-()}var c=null;if(b.H()=="["){b.a5(1);b.az();if(!b.Z("]"))return null;c=b.W();b.a5(1)}else b.by=o;if(!c){c=n;while(true){
-var k=c.indexOf("\n");if(k<0)break;var g=k;while(g>0&&ad(c.charAt(g-1)))g--;var e=k;while(e<c.length&&ad(c.charAt(e)))
-e++;c=c.substr(0,g)+" "+c.substr(e)}}var q=this.bw.GetLinkDefinition(c);if(q==null)return null;return this.O(h,new am(q,
-n))};a.aF=function(){var b=this.bB,c=b.by,e=0;while(b.aW("`"))e++;b.bd();if(b.J())return this.U(0,c,b.by-c);var g=b.by;
-if(!b.Z(b.E.substr(c,e)))return this.U(0,c,b.by-c);var h=b.by+e;while(ad(b.F(-1)))b.a5(-1);var j=this.U(7,g,b.by-g);b.by
-=h;return j};a.U=function(g,e,c){if(this.bG.length!=0){var b=this.bG.pop();b.type=g;b.startOffset=e;b.length=c;b.X=null;
-return b}else return new ax(g,e,c)};a.O=function(e,c){if(this.bG.length!=0){var b=this.bG.pop();b.type=e;b.X=c;return b}
-else{var b=new ax(e,0,0);b.X=c;return b}};a.ak=function(b){b.X=null;this.bG.push(b)};function B(){}a=B.prototype;a.E=
-null;a.v=0;a.R=0;a.N=0;a.ay=0;a.aA=0;a.C=null;a.X=null;a.an=function(){if(this.E==null)return null;if(this.R==-1)
-return this.E;return this.E.substr(this.R,this.N)};a.al=function(){var c=new F();for(var b=0;b<this.C.length;b++){c.x(
-this.C[b].an());c.x("\n")}return c.bh()};a.aN=function(e,c){for(var b=0;b<this.C.length;b++)this.C[b].l(e,c)};a.aX=
-function(e){if(typeof this.X=="string")return this.X;var c=at(this.E,this.R,this.ao()),b=null;if(c!=null){this.a3(c.end)
-;b=c.id}else b=e.aC(this.E,this.R,this.N);this.X=b;return b};a.l=function(c,b){switch(this.v){case 0:return;case 12:c.bz
-.ah(b,this.E,this.R,this.N);break;case 17:c.bz.ae(b,this.E,this.R,this.N);b.x("\n");break;case 1:case 2:case 3:case 4:
-case 5:case 6:if(c.ExtraMode&&!c.SafeMode){b.x("<h"+(this.v-1+1).toString());var k=this.aX(c);if(k){b.x(' id="');b.x(k);
-b.x('">')}else b.x(">")}else b.x("<h"+(this.v-1+1).toString()+">");c.bz.ae(b,this.E,this.R,this.N);b.x("</h"+(this.v-1+1
-).toString()+">\n");break;case 14:b.x("<hr />\n");return;case 10:case 11:b.x("<li>");c.bz.ae(b,this.E,this.R,this.N);b.x
-("</li>\n");break;case 15:b.x(this.E.substr(this.R,this.N));return;case 16:b.au(this.E,this.R,this.N);return;case 18:b.x
-("<pre");if(c.FormatCodeBlockAttributes!=null)b.x(c.FormatCodeBlockAttributes(this.X));b.x("><code>");var h=b;if(c.
-FormatCodeBlock){h=b;b=new F()}for(var e=0;e<this.C.length;e++){var j=this.C[e];b.av(j.E,j.R,j.N);b.x("\n")}if(c.
-FormatCodeBlock){h.x(c.FormatCodeBlock(b.bh(),this.X));b=h}b.x("</code></pre>\n\n");return;case 9:b.x("<blockquote>\n");
-this.aN(c,b);b.x("</blockquote>\n");return;case 19:b.x("<li>\n");this.aN(c,b);b.x("</li>\n");return;case 20:b.x("<ol>\n"
-);this.aN(c,b);b.x("</ol>\n");return;case 21:b.x("<ul>\n");this.aN(c,b);b.x("</ul>\n");return;case 22:var g=this.X,n=g.
-name.toLowerCase();if(n=="a")c.OnPrepareLink(g);else if(n=="img")c.OnPrepareImage(g,c.RenderingTitledImage);g.aS(b);b.x(
-"\n");this.aN(c,b);g.aO(b);b.x("\n");return;case 23:case 28:this.aN(c,b);return;case 24:this.X.l(c,b);return;case 25:b.x
-("<dd>");if(this.C!=null){b.x("\n");this.aN(c,b)}else c.bz.ae(b,this.E,this.R,this.N);b.x("</dd>\n");break;case 26:if(
-this.C==null){var m=this.an().split("\n");for(var e=0;e<m.length;e++){var o=m[e];b.x("<dt>");c.bz.af(b,ay(o));b.x(
-"</dt>\n")}}else{b.x("<dt>\n");this.aN(c,b);b.x("</dt>\n")}break;case 27:b.x("<dl>\n");this.aN(c,b);b.x("</dl>\n");
-return;case 29:b.x("<p>");if(this.N>0){c.bz.ae(b,this.E,this.R,this.N);b.x("&nbsp;")}b.x(this.X);b.x("</p>\n");break}};a
-.aY=function(){this.v=12;this.R=this.ay;this.N=this.aA};a.ao=function(){return this.R+this.N};a.a3=function(b){this.N=b-
-this.R};a.aq=function(){var c=0;for(var b=this.ay;b<this.ay+this.aA;b++)if(this.E.charAt(b)==" ")c++;else break;return c
-};a.V=function(b){this.v=b.v;this.E=b.E;this.R=b.R;this.N=b.N;this.ay=b.ay;this.aA=b.aA;return this};function D(b,c){
-this.bw=b;this.bx=0;this.bo=c}a=D.prototype;a.aH=function(c){var b=new G(c);return this.a1(b)};a.aL=function(g,e,b){var 
-c=new G(g,e,b);return this.a1(c)};a.bi=function(b,c,e){if(e.length>1)return false;if(e.length==1){var g=b.by;b.by=e[0].
-ay;c.bu=c.aG(b);if(c.bu==null)return false;b.by=g;e.length=0}while(true){var g=b.by,h=c.aG(b);if(h!=null){c.bA.push(h);
-continue}b.by=g;break}return true};a.a1=function(j){var e=[],c=[],k=-1;while(!j.J()){var m=k==0,b=this.ab(j);k=b.v;if(b.
-v==25)b.X=m;if(b.v==7||b.v==8){if(c.length>0){var g=c.pop();this.S(e,c);if(g.v!=0){g.aY();g.v=b.v==7?1:2;e.push(g);
-continue}}if(b.v==7){b.aY();c.push(b)}else if(b.N>=3){b.v=14;e.push(b)}else{b.aY();c.push(b)}continue}var h=c.length>0?c
-[0].v:0;if(b.v==24){var o=b.X,n=j.by;if(!this.bi(j,o,c)){j.by=n;b.aY()}else{e.push(b);continue}}switch(b.v){case 0:
-switch(h){case 0:this.ai(b);break;case 12:this.S(e,c);this.ai(b);break;case 9:case 10:case 11:case 25:case 28:case 13:c.
-push(b);break}break;case 12:switch(h){case 0:case 12:c.push(b);break;case 9:case 10:case 11:case 25:case 28:var g=c[c.
-length-1];if(g.v==0){this.S(e,c);c.push(b)}else c.push(b);break;case 13:this.S(e,c);c.push(b);break}break;case 13:
-switch(h){case 0:c.push(b);break;case 12:case 9:var g=c[c.length-1];if(g.v==0){this.S(e,c);c.push(b)}else{b.aY();c.push(
-b)}break;case 10:case 11:case 13:case 25:case 28:c.push(b);break}break;case 9:if(h!=9)this.S(e,c);c.push(b);break;case 
-10:case 11:switch(h){case 0:c.push(b);break;case 12:case 9:var g=c[c.length-1];if(g.v==0||this.bx==10||this.bx==11||this
-.bx==25){this.S(e,c);c.push(b)}else{b.aY();c.push(b)}break;case 10:case 11:if(b.v!=10&&b.v!=11)this.S(e,c);c.push(b);
-break;case 25:case 28:if(b.v!=h)this.S(e,c);c.push(b);break;case 13:this.S(e,c);c.push(b);break}break;case 25:case 28:
-switch(h){case 0:case 12:case 25:case 28:this.S(e,c);c.push(b);break;default:b.aY();c.push(b);break}break;default:this.S
-(e,c);e.push(b);break}}this.S(e,c);if(this.bw.ExtraMode)this.I(e);return e};a.T=function(c){var b;if(this.bw.bC.length>1
-)b=this.bw.bC.pop();else b=new B();b.ay=c;return b};a.ai=function(b){this.bw.bC.push(b)};a.aj=function(b){for(var c=0;c<
-b.length;c++)this.bw.bC.push(b[c]);b.length=0};a.aQ=function(g){var b=this.bw.as();for(var c=0;c<g.length;c++){var e=g[c
-];b.x(e.E.substr(e.R,e.N));b.x("\n")}return b.bh()};a.S=function(c,b){while(b.length>0&&b[b.length-1].v==0)this.ai(b.pop
-());if(b.length==0)return;switch(b[0].v){case 12:var h=this.T(b[0].ay);h.v=12;h.E=b[0].E;h.R=b[0].R;h.a3(b[b.length-1].
-ao());c.push(h);this.aj(b);break;case 9:var p=this.aQ(b),o=new D(this.bw,this.bo);o.bx=9;var n=this.T(b[0].ay);n.v=9;n.C
-=o.aH(p);this.aj(b);c.push(n);break;case 10:case 11:c.push(this.M(b));break;case 25:if(c.length>0){var j=c[c.length-1];
-switch(j.v){case 12:j.v=26;break;case 25:break;default:var k=this.T(j.ay);k.v=26;k.C=[];k.C.push(j);c.pop();c.push(k);
-break}}c.push(this.G(b));break;case 28:this.bw.z(this.L(b));break;case 13:var e=this.T(b[0].ay);e.v=18;e.C=[];var g=b[0]
-.an();if(g.substr(0,2)=="{{"&&g.substr(g.length-2,2)=="}}"){e.X=g.substr(2,g.length-4);b.splice(0,1)}for(var m=0;m<b.
-length;m++)e.C.push(b[m]);c.push(e);b.length=0;break}};a.ab=function(c){var b=this.T(c.by);b.E=c.E;b.R=c.by;b.N=-1;b.v=
-this.ac(c,b);if(b.N<0){c.bb();b.N=c.by-b.R}b.aA=c.by-b.ay;c.aZ();return b};a.ac=function(b,c){if(b.Y())return 0;var h=b.
-by,e=b.H();if(e=="#"){var j=1;b.a5(1);while(b.H()=="#"){j++;b.a5(1)}if(j>6)j=6;b.a8();c.R=b.by;b.bb();if(this.bw.
-ExtraMode&&!this.bw.SafeMode){var m=at(b.E,c.R,b.by);if(m!=null){c.X=m.id;b.by=m.end}}while(b.by>c.R&&b.F(-1)=="#")b.a5(
--1);while(b.by>c.R&&ad(b.F(-1)))b.a5(-1);c.N=b.by-c.R;b.bb();return 1+j-1}if(e=="-"||e=="="){var k=e;while(b.H()==k)b.a5
-(1);b.a8();if(b.Y())return k=="="?7:8;b.by=h}if(this.bw.ExtraMode){var s=av(b);if(s!=null){c.X=s;return 24}b.by=h;if(e==
-"~"||e=="`"){if(this.aJ(b,c))return c.v;b.by=h}}var g=-1,r=0;while(!b.Y()){if(b.H()==" "){if(g<0)r++}else if(b.H()=="\t"
-){if(g<0)g=b.by}else break;b.a5(1)}if(b.Y()){c.N=0;return 0}if(r>=4){c.R=h+4;return 13}if(g>=0&&g-h<4){c.R=g+1;return 13
-}c.R=b.by;e=b.H();if(e=="<"){if(this.a0(b,c))return c.v;b.by=c.R}if(e==">"){if(ab(b.F(1))){b.a5(2);c.R=b.by;return 9}b.
-a5(1);c.R=b.by;return 9}if(e=="-"||e=="_"||e=="*"){var o=0;while(!b.Y()){var k=b.H();if(b.H()==e){o++;b.a5(1);continue}
-if(ab(b.H())){b.a5(1);continue}break}if(b.Y()&&o>=3)return 14;b.by=c.R}if(this.bw.ExtraMode&&e=="*"&&b.F(1)=="["){b.a5(2
-);b.a8();b.az();while(!b.Y()&&b.H()!="]")b.a5(1);var n=ay(b.W());if(b.H()=="]"&&b.F(1)==":"&&n){b.a5(2);b.a8();b.az();b.
-bb();var v=b.W();this.bw.y(n,v);return 0}b.by=c.R}if((e=="*"||e=="+"||e=="-")&&ab(b.F(1))){b.a5(1);b.a8();c.R=b.by;
-return 11}if(e==":"&&this.bw.ExtraMode&&ab(b.F(1))){b.a5(1);b.a8();c.R=b.by;return 25}if(X(e)){b.a5(1);while(X(b.H()))b.
-a5(1);if(b.aW(".")&&b.a8()){c.R=b.by;return 10}b.by=c.R}if(e=="["){if(this.bw.ExtraMode&&b.F(1)=="^"){var t=b.by;b.a5(2)
-;var p=b.a4();if(p!=null&&b.aW("]")&&b.aW(":")){b.a8();c.R=b.by;c.X=p;return 28}b.by=t}var q=an(b,this.bw.ExtraMode);if(
-q!=null){this.bw.A(q);return 0}}return 12};a.ar=function(c){var b=c.attributes.markdown;if(b==undefined)if(this.bo)
-return 3;else return 0;delete c.attributes.markdown;if(b=="1")return(c.ap()&8)!=0?2:1;if(b=="block")return 1;if(b==
-"deep")return 3;if(b=="span")return 2;return 4};a.aK=function(b,e,o,m){var g=b.by,k=1,j=false;while(!b.J()){if(!b.Z("<")
-)break;var n=b.by,h=ag(b);if(h==null){b.a5(1);continue}if(this.bw.SafeMode&&m==4&&!j)if(!h.at())j=true;if(h.closed)
-continue;if(h.name==o.name)if(h.closing){k--;if(k==0){b.a8();b.aZ();e.v=22;e.X=o;e.a3(b.by);switch(m){case 2:var c=this.
-T(g);c.E=b.E;c.v=17;c.R=g;c.N=n-g;e.C=[];e.C.push(c);break;case 1:case 3:var p=new D(this.bw,m==3);e.C=p.aL(b.E,g,n-g);
-break;case 4:if(j){e.v=16;e.a3(b.by)}else{var c=this.T(g);c.E=b.E;c.v=15;c.R=g;c.N=n-g;e.C=[];e.C.push(c)}break}
-return true}}else k++}return false};a.a0=function(b,c){var g=b.by,h=ag(b);if(h==null)return false;if(h.closing)
-return false;var m=false;if(this.bw.SafeMode&&!h.at())m=true;var q=h.ap();if((q&1)==0)return false;if((q&4)!=0||h.closed
-){b.a8();b.aZ();c.N=b.by-c.R;c.v=m?16:15;return true}if((q&2)!=0){b.a8();if(!b.Y())return false}var o=this.bw.
-ExtractHeadBlocks&&h.name.toLowerCase()=="head",t=b.by;if(!o&&this.bw.ExtraMode){var n=this.ar(h);if(n!=0)return this.aK
-(b,c,h,n)}var k=null,p=1;while(!b.J()){if(!b.Z("<"))break;var s=b.by,j=ag(b);if(j==null){b.a5(1);continue}if(this.bw.
-SafeMode&&!j.at())m=true;if(j.closed)continue;if(!o&&!j.closing&&this.bw.ExtraMode&&!m){var n=this.ar(j);if(n!=0){var r=
-this.T(g);if(this.aK(b,r,j,n)){if(k==null)k=[];if(s>g){var e=this.T(g);e.E=b.E;e.v=15;e.R=g;e.N=s-g;k.push(e)}k.push(r);
-g=b.by;continue}else this.ai(r)}}if(j.name==h.name&&!j.closed)if(j.closing){p--;if(p==0){b.a8();b.aZ();if(m){c.v=16;c.a3
-(b.by);return true}if(k!=null){if(b.by>g){var e=this.T(g);e.E=b.E;e.v=15;e.R=g;e.N=b.by-g;k.push(e)}c.v=23;c.a3(b.by);c.
-C=k;return true}if(o){var v=b.E.substr(t,s-t);this.bw.HeadBlockContent=this.bw.HeadBlockContent+ay(v)+"\n";c.v=15;c.R=b.
-bK;c.contentEnd=b.bK;c.ay=b.bK;return true}c.v=15;c.N=b.by-c.R;return true}}else p++}return 0};a.M=function(b){var r=b[0
-].v,t=b[0].aq();for(var c=1;c<b.length;c++){if(b[c].v==12&&(b[c-1].v==12||b[c-1].v==11||b[c-1].v==10)){b[c-1].a3(b[c].ao
-());this.ai(b[c]);b.splice(c,1);c--;continue}if(b[c].v!=13&&b[c].v!=0){var s=b[c].aq();if(s>t){b[c].v=13;var v=b[c].ao()
-;b[c].R=b[c].ay+s;b[c].a3(v)}}}var h=this.T(0);h.v=r==11?21:20;h.C=[];for(var c=0;c<b.length;c++){var k=c;while(k>0&&b[k
--1].v==0)k--;var g=c;while(g<b.length-1&&b[g+1].v!=11&&b[g+1].v!=10)g++;if(k==g)h.C.push(this.T().V(b[c]));else{var o=
-false,n=this.bw.as();for(var e=k;e<=g;e++){var m=b[e];n.x(m.E.substr(m.R,m.N));n.x("\n");if(b[e].v==0)o=true}var j=this.
-T();j.v=19;j.ay=b[k].ay;var p=new D(this.bw);p.bx=r;j.C=p.aH(n.bh());if(!o)for(var e=0;e<j.C.length;e++){var q=j.C[e];
-if(q.v==12)q.v=17}h.C.push(j)}c=g}h.ay=h.C[0].ay;this.aj(b);b.length=0;return h};a.G=function(b){for(var c=1;c<b.length;
-c++)if(b[c].v==12&&(b[c-1].v==12||b[c-1].v==25)){b[c-1].a3(b[c].ao());this.ai(b[c]);b.splice(c,1);c--;continue}var k=b[0
-].X;if(b.length==1&&!k){var m=b[0];b.length=0;return m}var h=this.bw.as();for(var c=0;c<b.length;c++){var g=b[c];h.x(g.E
-.substr(g.R,g.N));h.x("\n")}var e=this.T(b[0].ay);e.v=25;var j=new D(this.bw);j.bx=25;e.C=j.aH(h.bh());this.aj(b);b.
-length=0;return e};a.I=function(e){var c=null;for(var b=0;b<e.length;b++)switch(e[b].v){case 26:case 25:if(c==null){c=
-this.T(e[b].ay);c.v=27;c.C=[];e.splice(b,0,c);b++}c.C.push(e[b]);e.splice(b,1);b--;break;default:c=null;break}};a.L=
-function(c){for(var b=1;b<c.length;b++)if(c[b].v==12&&(c[b-1].v==12||c[b-1].v==28)){c[b-1].a3(c[b].ao());this.ai(c[b]);c
-.splice(b,1);b--;continue}var h=this.bw.as();for(var b=0;b<c.length;b++){var g=c[b];h.x(g.E.substr(g.R,g.N));h.x("\n")}
-var j=new D(this.bw);j.bx=28;var e=this.T(c[0].ay);e.v=28;e.X=c[0].X;e.C=j.aH(h.bh());this.aj(c);c.length=0;return e};a.
-aJ=function(b,e){var m=b.by,k=b.H();b.az();while(b.H()==k)b.a5(1);var g=b.W();if(g.length<3)return false;b.a8();if(!b.Y(
-))return false;b.aZ();var j=b.by;if(!b.Z(g))return false;if(!Y(b.F(-1)))return false;var h=b.by;b.a5(g.length);b.a8();
-if(!b.Y())return false;e.v=18;e.C=[];h--;var c=this.T(m);c.v=13;c.E=b.E;c.R=j;c.N=h-j;e.C.push(c);return true};function 
-H(){this.bp=[];this.bu=null;this.bA=[]}a=H.prototype;a.ax=false;a.bk=false;a.aG=function(b){b.a8();if(b.Y())return null;
-var e=this.ax;if(this.ax&&!b.aW("|")){e=true;return null}var c=[];while(!b.Y()){b.az();while(!b.Y()&&b.H()!="|")b.a2(
-true);c.push(ay(b.W()));e|=b.aW("|")}if(!e)return null;while(c.length<this.bp.length)c.push("&nbsp;");b.aZ();return c};a
-.aT=function(h,b,e,g){for(var c=0;c<e.length;c++){b.x("\t<");b.x(g);if(c<this.bp.length)switch(this.bp[c]){case 1:b.x(
-' align="left"');break;case 2:b.x(' align="right"');break;case 3:b.x(' align="center"');break}b.x(">");h.bz.af(b,e[c]);b
-.x("</");b.x(g);b.x(">\n")}};a.l=function(e,b){b.x("<table>\n");if(this.bu!=null){b.x("<thead>\n<tr>\n");this.aT(e,b,
-this.bu,"th");b.x("</tr>\n</thead>\n")}b.x("<tbody>\n");for(var c=0;c<this.bA.length;c++){var g=this.bA[c];b.x("<tr>\n")
-;this.aT(e,b,g,"td");b.x("</tr>\n")}b.x("</tbody>\n");b.x("</table>\n")};function av(b){b.a8();if(b.H()!="|"&&b.H()!=":"
-&&b.H()!="-")return null;var c=null;if(b.aW("|")){c=new H();c.ax=true}while(true){b.a8();if(b.H()=="|")return null;var g
-=b.aW(":");while(b.H()=="-")b.a5(1);var h=b.aW(":");b.a8();var e=0;if(g&&h)e=3;else if(g)e=1;else if(h)e=2;if(b.Y()){if(
-c==null)return null;c.bp.push(e);return c}if(!b.aW("|"))return null;if(c==null)c=new H();c.bp.push(e);b.a8();if(b.Y()){c
-.bk=true;return c}}}this.Markdown=i;this.HtmlTag=w})();if(typeof exports!=="undefined")exports.Markdown=MarkdownDeep.
-Markdown
+"<":var e=b.by,p=ag(b);if(p!=null)if((!this.bw.SafeMode||p.at())&&this.bw.AllowUserHtml)c=this.U(1,e,b.by-e);else b.by=e
+;else{b.by=e;c=this.aD();if(c==null)b.by=e}break;case"&":var e=b.by;if(b.a6())c=this.U(2,e,b.by-e);break;case" ":if(b.F(
+1)==" "&&Y(b.F(2))){b.a5(2);if(!b.J()){b.aZ();c=this.U(8,m,0)}}break;case"\\":if(U(b.F(1),q)){c=this.U(0,b.by+1,1);b.a5(
+2)}break}if(c==null&&k!=null&&!R(b.F(-1))){var v=b.by;for(var r in k){var n=k[r];if(b.a9(n.Abbr)&&!R(b.H())){c=this.O(15
+,n);break}b.bK=v}}if(c!=null){if(m>g)j.push(this.U(0,g,m-g));j.push(c);g=b.by}else b.a5(1)}if(b.by>g)j.push(this.U(0,g,b
+.by-g));if(h!=null)this.aV(j,h)};a.P=function(){var b=this.bB,e=b.H(),k=e=="*"?"_":"*",c=b.by;if(b.D()||ad(b.F(-1))){
+while(ae(b.H()))b.a5(1);if(b.J()||ad(b.H()))return this.U(2,c,b.by-c);b.by=c}while(ae(b.F(-1)))b.a5(-1);var h=b.D()||ad(
+b.F(-1));b.by=c;while(b.H()==e)b.a5(1);var j=b.by-c;while(ae(b.F(1)))b.a5(1);var g=b.J()||ad(b.H());b.by=c+j;if(h)
+return this.U(11,c,b.by-c);if(g)return this.U(12,c,b.by-c);if(this.bw.ExtraMode&&e=="_"&&R(b.H()))return null;
+return this.U(13,c,b.by-c)};a.bg=function(h,g,b,c){var e=this.U(b.type,b.startOffset+c,b.length-c);b.length=c;g.splice(S
+(g,b)+1,0,e);h.splice(S(h,b)+1,0,e);return e};a.aV=function(n,b){var m=this.bB.E,j=true;while(j){j=false;for(var h=0;h<b
+.length;h++){var c=b[h];if(c.type!=11&&c.type!=13)continue;for(var k=h+1;k<b.length;k++){var g=b[k];if(g.type!=12&&g.
+type!=13)break;if(m.charAt(c.startOffset)!=m.charAt(g.startOffset))continue;var e=Math.min(c.length,g.length);if(e>=3)e=
+e%2==1?1:2;if(c.length>e){c=this.bg(n,b,c,c.length-e);h--}if(g.length>e)this.bg(n,b,g,e);c.type=e==1?3:5;g.type=e==1?4:6
+;b.splice(S(b,c),1);b.splice(S(b,g),1);j=true;break}}}};a.aD=function(){if(this.br)return null;var c=this.bB;c.a5(1);c.
+az();var j=this.bw.ExtraMode;while(!c.J()){var h=c.H();if(ad(h))break;if(h==">"){var b=az(c.W(),j),e=null;if(ah(b)){var 
+g;if(b.toLowerCase().substr(0,7)=="mailto:")g=b.substr(7);else{g=b;b="mailto:"+b}e=new am(new C("auto",b,null),g)}else 
+if(al(b))e=new am(new C("auto",b,null),b);if(e!=null){c.a5(1);return this.O(9,e)}return null}c.a2(j)}return null};a.aI=
+function(){var b=this.bB,h=b.aW("!")?10:9;if(!b.aW("["))return null;var o=this.by;if(this.bw.ExtraMode&&h==9&&b.aW("^"))
+{b.a8();b.az();var m=b.a4();if(m!=null&&b.aW("]")){var s=this.bw.Q(m);if(s>=0)return this.O(14,{index:s,id:m})}this.by=o
+}if(this.br&&h==9)return null;var r=this.bw.ExtraMode;b.az();var j=1;while(!b.J()){var p=b.H();if(p=="[")j++;else if(p==
+"]"){j--;if(j==0)break}b.a2(r)}if(b.J())return null;var n=az(b.W(),r);b.a5(1);o=b.by;if(b.aW("(")){var t=ar(b,null,this.
+bw.ExtraMode);if(t==null)return null;b.bd();if(!b.aW(")"))return null;return this.O(h,new am(t,n))}if(!b.aW(" "))b.aW(
+"\t");if(b.Y()){b.aZ();b.a8()}var c=null;if(b.H()=="["){b.a5(1);b.az();if(!b.Z("]"))return null;c=b.W();b.a5(1)}else b.
+by=o;if(!c){c=n;while(true){var k=c.indexOf("\n");if(k<0)break;var g=k;while(g>0&&ad(c.charAt(g-1)))g--;var e=k;while(e<
+c.length&&ad(c.charAt(e)))e++;c=c.substr(0,g)+" "+c.substr(e)}}var q=this.bw.GetLinkDefinition(c);if(q==null)return null
+;return this.O(h,new am(q,n))};a.aF=function(){var b=this.bB,c=b.by,e=0;while(b.aW("`"))e++;b.bd();if(b.J())return this.
+U(0,c,b.by-c);var g=b.by;if(!b.Z(b.E.substr(c,e)))return this.U(0,c,b.by-c);var h=b.by+e;while(ad(b.F(-1)))b.a5(-1);var 
+j=this.U(7,g,b.by-g);b.by=h;return j};a.U=function(g,e,c){if(this.bG.length!=0){var b=this.bG.pop();b.type=g;b.
+startOffset=e;b.length=c;b.X=null;return b}else return new ax(g,e,c)};a.O=function(e,c){if(this.bG.length!=0){var b=this
+.bG.pop();b.type=e;b.X=c;return b}else{var b=new ax(e,0,0);b.X=c;return b}};a.ak=function(b){b.X=null;this.bG.push(b)};
+function B(){}a=B.prototype;a.E=null;a.v=0;a.R=0;a.N=0;a.ay=0;a.aA=0;a.C=null;a.X=null;a.an=function(){if(this.E==null)
+return null;if(this.R==-1)return this.E;return this.E.substr(this.R,this.N)};a.al=function(){var c=new F();for(var b=0;b
+<this.C.length;b++){c.x(this.C[b].an());c.x("\n")}return c.bh()};a.aN=function(e,c){for(var b=0;b<this.C.length;b++)this
+.C[b].l(e,c)};a.aX=function(e){if(typeof this.X=="string")return this.X;var c=at(this.E,this.R,this.ao()),b=null;if(c!=
+null){this.a3(c.end);b=c.id}else b=e.aC(this.E,this.R,this.N);this.X=b;return b};a.l=function(c,b){switch(this.v){case 0
+:return;case 12:c.bz.ah(b,this.E,this.R,this.N);break;case 17:c.bz.ae(b,this.E,this.R,this.N);b.x("\n");break;case 1:
+case 2:case 3:case 4:case 5:case 6:if(c.ExtraMode&&!c.SafeMode){b.x("<h"+(this.v-1+1).toString());var k=this.aX(c);if(k)
+{b.x(' id="');b.x(k);b.x('">')}else b.x(">")}else b.x("<h"+(this.v-1+1).toString()+">");c.bz.ae(b,this.E,this.R,this.N);
+b.x("</h"+(this.v-1+1).toString()+">\n");break;case 14:b.x("<hr />\n");return;case 10:case 11:b.x("<li>");c.bz.ae(b,this
+.E,this.R,this.N);b.x("</li>\n");break;case 15:b.x(this.E.substr(this.R,this.N));return;case 16:b.au(this.E,this.R,this.
+N);return;case 18:b.x("<pre");if(c.FormatCodeBlockAttributes!=null)b.x(c.FormatCodeBlockAttributes(this.X));b.x(
+"><code>");var h=b;if(c.FormatCodeBlock){h=b;b=new F()}for(var e=0;e<this.C.length;e++){var j=this.C[e];b.av(j.E,j.R,j.N
+);b.x("\n")}if(c.FormatCodeBlock){h.x(c.FormatCodeBlock(b.bh(),this.X));b=h}b.x("</code></pre>\n\n");return;case 9:b.x(
+"<blockquote>\n");this.aN(c,b);b.x("</blockquote>\n");return;case 19:b.x("<li>\n");this.aN(c,b);b.x("</li>\n");return;
+case 20:b.x("<ol>\n");this.aN(c,b);b.x("</ol>\n");return;case 21:b.x("<ul>\n");this.aN(c,b);b.x("</ul>\n");return;case 
+22:var g=this.X,n=g.name.toLowerCase();if(n=="a")c.OnPrepareLink(g);else if(n=="img")c.OnPrepareImage(g,c.
+RenderingTitledImage);g.aS(b);b.x("\n");this.aN(c,b);g.aO(b);b.x("\n");return;case 23:case 28:this.aN(c,b);return;case 
+24:this.X.l(c,b);return;case 25:b.x("<dd>");if(this.C!=null){b.x("\n");this.aN(c,b)}else c.bz.ae(b,this.E,this.R,this.N)
+;b.x("</dd>\n");break;case 26:if(this.C==null){var m=this.an().split("\n");for(var e=0;e<m.length;e++){var o=m[e];b.x(
+"<dt>");c.bz.af(b,ay(o));b.x("</dt>\n")}}else{b.x("<dt>\n");this.aN(c,b);b.x("</dt>\n")}break;case 27:b.x("<dl>\n");this
+.aN(c,b);b.x("</dl>\n");return;case 29:b.x("<p>");if(this.N>0){c.bz.ae(b,this.E,this.R,this.N);b.x("&nbsp;")}b.x(this.X)
+;b.x("</p>\n");break}};a.aY=function(){this.v=12;this.R=this.ay;this.N=this.aA};a.ao=function(){return this.R+this.N};a.
+a3=function(b){this.N=b-this.R};a.aq=function(){var c=0;for(var b=this.ay;b<this.ay+this.aA;b++)if(this.E.charAt(b)==" "
+)c++;else break;return c};a.V=function(b){this.v=b.v;this.E=b.E;this.R=b.R;this.N=b.N;this.ay=b.ay;this.aA=b.aA;
+return this};function D(b,c){this.bw=b;this.bx=0;this.bo=c}a=D.prototype;a.aH=function(c){var b=new G(c);return this.a1(
+b)};a.aL=function(g,e,b){var c=new G(g,e,b);return this.a1(c)};a.bi=function(b,c,e){if(e.length>1)return false;if(e.
+length==1){var g=b.by;b.by=e[0].ay;c.bu=c.aG(b);if(c.bu==null)return false;b.by=g;e.length=0}while(true){var g=b.by,h=c.
+aG(b);if(h!=null){c.bA.push(h);continue}b.by=g;break}return true};a.a1=function(j){var e=[],c=[],k=-1;while(!j.J()){var 
+m=k==0,b=this.ab(j);k=b.v;if(b.v==25)b.X=m;if(b.v==7||b.v==8){if(c.length>0){var g=c.pop();this.S(e,c);if(g.v!=0){g.aY()
+;g.v=b.v==7?1:2;e.push(g);continue}}if(b.v==7){b.aY();c.push(b)}else if(b.N>=3){b.v=14;e.push(b)}else{b.aY();c.push(b)}
+continue}var h=c.length>0?c[0].v:0;if(b.v==24){var o=b.X,n=j.by;if(!this.bi(j,o,c)){j.by=n;b.aY()}else{e.push(b);
+continue}}switch(b.v){case 0:switch(h){case 0:this.ai(b);break;case 12:this.S(e,c);this.ai(b);break;case 9:case 10:case 
+11:case 25:case 28:case 13:c.push(b);break}break;case 12:switch(h){case 0:case 12:c.push(b);break;case 9:case 10:case 11
+:case 25:case 28:var g=c[c.length-1];if(g.v==0){this.S(e,c);c.push(b)}else c.push(b);break;case 13:this.S(e,c);c.push(b)
+;break}break;case 13:switch(h){case 0:c.push(b);break;case 12:case 9:var g=c[c.length-1];if(g.v==0){this.S(e,c);c.push(b
+)}else{b.aY();c.push(b)}break;case 10:case 11:case 13:case 25:case 28:c.push(b);break}break;case 9:if(h!=9)this.S(e,c);c
+.push(b);break;case 10:case 11:switch(h){case 0:c.push(b);break;case 12:case 9:var g=c[c.length-1];if(g.v==0||this.bx==
+10||this.bx==11||this.bx==25){this.S(e,c);c.push(b)}else{b.aY();c.push(b)}break;case 10:case 11:if(b.v!=10&&b.v!=11)this
+.S(e,c);c.push(b);break;case 25:case 28:if(b.v!=h)this.S(e,c);c.push(b);break;case 13:this.S(e,c);c.push(b);break}break;
+case 25:case 28:switch(h){case 0:case 12:case 25:case 28:this.S(e,c);c.push(b);break;default:b.aY();c.push(b);break}
+break;default:this.S(e,c);e.push(b);break}}this.S(e,c);if(this.bw.ExtraMode)this.I(e);return e};a.T=function(c){var b;
+if(this.bw.bC.length>1)b=this.bw.bC.pop();else b=new B();b.ay=c;return b};a.ai=function(b){this.bw.bC.push(b)};a.aj=
+function(b){for(var c=0;c<b.length;c++)this.bw.bC.push(b[c]);b.length=0};a.aQ=function(g){var b=this.bw.as();for(var c=0
+;c<g.length;c++){var e=g[c];b.x(e.E.substr(e.R,e.N));b.x("\n")}return b.bh()};a.S=function(c,b){while(b.length>0&&b[b.
+length-1].v==0)this.ai(b.pop());if(b.length==0)return;switch(b[0].v){case 12:var h=this.T(b[0].ay);h.v=12;h.E=b[0].E;h.R
+=b[0].R;h.a3(b[b.length-1].ao());c.push(h);this.aj(b);break;case 9:var p=this.aQ(b),o=new D(this.bw,this.bo);o.bx=9;var 
+n=this.T(b[0].ay);n.v=9;n.C=o.aH(p);this.aj(b);c.push(n);break;case 10:case 11:c.push(this.M(b));break;case 25:if(c.
+length>0){var j=c[c.length-1];switch(j.v){case 12:j.v=26;break;case 25:break;default:var k=this.T(j.ay);k.v=26;k.C=[];k.
+C.push(j);c.pop();c.push(k);break}}c.push(this.G(b));break;case 28:this.bw.z(this.L(b));break;case 13:var e=this.T(b[0].
+ay);e.v=18;e.C=[];var g=b[0].an();if(g.substr(0,2)=="{{"&&g.substr(g.length-2,2)=="}}"){e.X=g.substr(2,g.length-4);b.
+splice(0,1)}for(var m=0;m<b.length;m++)e.C.push(b[m]);c.push(e);b.length=0;break}};a.ab=function(c){var b=this.T(c.by);b
+.E=c.E;b.R=c.by;b.N=-1;b.v=this.ac(c,b);if(b.N<0){c.bb();b.N=c.by-b.R}b.aA=c.by-b.ay;c.aZ();return b};a.ac=function(b,c)
+{if(b.Y())return 0;var h=b.by,e=b.H();if(e=="#"){var j=1;b.a5(1);while(b.H()=="#"){j++;b.a5(1)}if(j>6)j=6;b.a8();c.R=b.
+by;b.bb();if(this.bw.ExtraMode&&!this.bw.SafeMode){var m=at(b.E,c.R,b.by);if(m!=null){c.X=m.id;b.by=m.end}}while(b.by>c.
+R&&b.F(-1)=="#")b.a5(-1);while(b.by>c.R&&ad(b.F(-1)))b.a5(-1);c.N=b.by-c.R;b.bb();return 1+j-1}if(e=="-"||e=="="){var k=
+e;while(b.H()==k)b.a5(1);b.a8();if(b.Y())return k=="="?7:8;b.by=h}if(this.bw.ExtraMode){var s=av(b);if(s!=null){c.X=s;
+return 24}b.by=h;if(e=="~"||e=="`"){if(this.aJ(b,c))return c.v;b.by=h}}var g=-1,r=0;while(!b.Y()){if(b.H()==" "){if(g<0)
+r++}else if(b.H()=="\t"){if(g<0)g=b.by}else break;b.a5(1)}if(b.Y()){c.N=0;return 0}if(r>=4){c.R=h+4;return 13}if(g>=0&&g
+-h<4){c.R=g+1;return 13}c.R=b.by;e=b.H();if(e=="<"){if(this.a0(b,c))return c.v;b.by=c.R}if(e==">"){if(ab(b.F(1))){b.a5(2
+);c.R=b.by;return 9}b.a5(1);c.R=b.by;return 9}if(e=="-"||e=="_"||e=="*"){var o=0;while(!b.Y()){var k=b.H();if(b.H()==e){
+o++;b.a5(1);continue}if(ab(b.H())){b.a5(1);continue}break}if(b.Y()&&o>=3)return 14;b.by=c.R}if(this.bw.ExtraMode&&e=="*"
+&&b.F(1)=="["){b.a5(2);b.a8();b.az();while(!b.Y()&&b.H()!="]")b.a5(1);var n=ay(b.W());if(b.H()=="]"&&b.F(1)==":"&&n){b.
+a5(2);b.a8();b.az();b.bb();var v=b.W();this.bw.y(n,v);return 0}b.by=c.R}if((e=="*"||e=="+"||e=="-")&&ab(b.F(1))){b.a5(1)
+;b.a8();c.R=b.by;return 11}if(e==":"&&this.bw.ExtraMode&&ab(b.F(1))){b.a5(1);b.a8();c.R=b.by;return 25}if(X(e)){b.a5(1);
+while(X(b.H()))b.a5(1);if(b.aW(".")&&b.a8()){c.R=b.by;return 10}b.by=c.R}if(e=="["){if(this.bw.ExtraMode&&b.F(1)=="^"){
+var t=b.by;b.a5(2);var p=b.a4();if(p!=null&&b.aW("]")&&b.aW(":")){b.a8();c.R=b.by;c.X=p;return 28}b.by=t}var q=an(b,this
+.bw.ExtraMode);if(q!=null){this.bw.A(q);return 0}}return 12};a.ar=function(c){var b=c.attributes.markdown;if(b==
+undefined)if(this.bo)return 3;else return 0;delete c.attributes.markdown;if(b=="1")return(c.ap()&8)!=0?2:1;if(b=="block"
+)return 1;if(b=="deep")return 3;if(b=="span")return 2;return 4};a.aK=function(b,e,o,m){var g=b.by,k=1,j=false;while(!b.J
+()){if(!b.Z("<"))break;var n=b.by,h=ag(b);if(h==null){b.a5(1);continue}if(this.bw.SafeMode&&m==4&&!j)if(!h.at())j=true;
+if(h.closed)continue;if(h.name==o.name)if(h.closing){k--;if(k==0){b.a8();b.aZ();e.v=22;e.X=o;e.a3(b.by);switch(m){case 2
+:var c=this.T(g);c.E=b.E;c.v=17;c.R=g;c.N=n-g;e.C=[];e.C.push(c);break;case 1:case 3:var p=new D(this.bw,m==3);e.C=p.aL(
+b.E,g,n-g);break;case 4:if(j){e.v=16;e.a3(b.by)}else{var c=this.T(g);c.E=b.E;c.v=15;c.R=g;c.N=n-g;e.C=[];e.C.push(c)}
+break}return true}}else k++}return false};a.a0=function(b,c){var g=b.by,h=ag(b);if(h==null)return false;if(h.closing)
+return false;var m=false;if(this.bw.SafeMode&&!h.at()||!this.bw.AllowUserHtml)m=true;var q=h.ap();if((q&1)==0)
+return false;if((q&4)!=0||h.closed){b.a8();b.aZ();c.N=b.by-c.R;c.v=m?16:15;return true}if((q&2)!=0){b.a8();if(!b.Y())
+return false}var o=this.bw.ExtractHeadBlocks&&h.name.toLowerCase()=="head",t=b.by;if(!o&&this.bw.ExtraMode){var n=this.
+ar(h);if(n!=0)return this.aK(b,c,h,n)}var k=null,p=1;while(!b.J()){if(!b.Z("<"))break;var s=b.by,j=ag(b);if(j==null){b.
+a5(1);continue}if(this.bw.SafeMode&&!j.at())m=true;if(j.closed)continue;if(!o&&!j.closing&&this.bw.ExtraMode&&!m){var n=
+this.ar(j);if(n!=0){var r=this.T(g);if(this.aK(b,r,j,n)){if(k==null)k=[];if(s>g){var e=this.T(g);e.E=b.E;e.v=15;e.R=g;e.
+N=s-g;k.push(e)}k.push(r);g=b.by;continue}else this.ai(r)}}if(j.name==h.name&&!j.closed)if(j.closing){p--;if(p==0){b.a8(
+);b.aZ();if(m){c.v=16;c.a3(b.by);return true}if(k!=null){if(b.by>g){var e=this.T(g);e.E=b.E;e.v=15;e.R=g;e.N=b.by-g;k.
+push(e)}c.v=23;c.a3(b.by);c.C=k;return true}if(o){var v=b.E.substr(t,s-t);this.bw.HeadBlockContent=this.bw.
+HeadBlockContent+ay(v)+"\n";c.v=15;c.R=b.bK;c.contentEnd=b.bK;c.ay=b.bK;return true}c.v=15;c.N=b.by-c.R;return true}}
+else p++}return 0};a.M=function(b){var r=b[0].v,t=b[0].aq();for(var c=1;c<b.length;c++){if(b[c].v==12&&(b[c-1].v==12||b[
+c-1].v==11||b[c-1].v==10)){b[c-1].a3(b[c].ao());this.ai(b[c]);b.splice(c,1);c--;continue}if(b[c].v!=13&&b[c].v!=0){var s
+=b[c].aq();if(s>t){b[c].v=13;var v=b[c].ao();b[c].R=b[c].ay+s;b[c].a3(v)}}}var h=this.T(0);h.v=r==11?21:20;h.C=[];for(
+var c=0;c<b.length;c++){var k=c;while(k>0&&b[k-1].v==0)k--;var g=c;while(g<b.length-1&&b[g+1].v!=11&&b[g+1].v!=10)g++;
+if(k==g)h.C.push(this.T().V(b[c]));else{var o=false,n=this.bw.as();for(var e=k;e<=g;e++){var m=b[e];n.x(m.E.substr(m.R,m
+.N));n.x("\n");if(b[e].v==0)o=true}var j=this.T();j.v=19;j.ay=b[k].ay;var p=new D(this.bw);p.bx=r;j.C=p.aH(n.bh());if(!o
+)for(var e=0;e<j.C.length;e++){var q=j.C[e];if(q.v==12)q.v=17}h.C.push(j)}c=g}h.ay=h.C[0].ay;this.aj(b);b.length=0;
+return h};a.G=function(b){for(var c=1;c<b.length;c++)if(b[c].v==12&&(b[c-1].v==12||b[c-1].v==25)){b[c-1].a3(b[c].ao());
+this.ai(b[c]);b.splice(c,1);c--;continue}var k=b[0].X;if(b.length==1&&!k){var m=b[0];b.length=0;return m}var h=this.bw.
+as();for(var c=0;c<b.length;c++){var g=b[c];h.x(g.E.substr(g.R,g.N));h.x("\n")}var e=this.T(b[0].ay);e.v=25;var j=new D(
+this.bw);j.bx=25;e.C=j.aH(h.bh());this.aj(b);b.length=0;return e};a.I=function(e){var c=null;for(var b=0;b<e.length;b++)
+switch(e[b].v){case 26:case 25:if(c==null){c=this.T(e[b].ay);c.v=27;c.C=[];e.splice(b,0,c);b++}c.C.push(e[b]);e.splice(b
+,1);b--;break;default:c=null;break}};a.L=function(c){for(var b=1;b<c.length;b++)if(c[b].v==12&&(c[b-1].v==12||c[b-1].v==
+28)){c[b-1].a3(c[b].ao());this.ai(c[b]);c.splice(b,1);b--;continue}var h=this.bw.as();for(var b=0;b<c.length;b++){var g=
+c[b];h.x(g.E.substr(g.R,g.N));h.x("\n")}var j=new D(this.bw);j.bx=28;var e=this.T(c[0].ay);e.v=28;e.X=c[0].X;e.C=j.aH(h.
+bh());this.aj(c);c.length=0;return e};a.aJ=function(b,e){var m=b.by,k=b.H();b.az();while(b.H()==k)b.a5(1);var g=b.W();
+if(g.length<3)return false;b.a8();if(!b.Y())return false;b.aZ();var j=b.by;if(!b.Z(g))return false;if(!Y(b.F(-1)))
+return false;var h=b.by;b.a5(g.length);b.a8();if(!b.Y())return false;e.v=18;e.C=[];h--;var c=this.T(m);c.v=13;c.E=b.E;c.
+R=j;c.N=h-j;e.C.push(c);return true};function H(){this.bp=[];this.bu=null;this.bA=[]}a=H.prototype;a.ax=false;a.bk=false
+;a.aG=function(b){b.a8();if(b.Y())return null;var e=this.ax;if(this.ax&&!b.aW("|")){e=true;return null}var c=[];while(!b
+.Y()){b.az();while(!b.Y()&&b.H()!="|")b.a2(true);c.push(ay(b.W()));e|=b.aW("|")}if(!e)return null;while(c.length<this.bp
+.length)c.push("&nbsp;");b.aZ();return c};a.aT=function(h,b,e,g){for(var c=0;c<e.length;c++){b.x("\t<");b.x(g);if(c<this
+.bp.length)switch(this.bp[c]){case 1:b.x(' align="left"');break;case 2:b.x(' align="right"');break;case 3:b.x(
+' align="center"');break}b.x(">");h.bz.af(b,e[c]);b.x("</");b.x(g);b.x(">\n")}};a.l=function(e,b){b.x("<table>\n");if(
+this.bu!=null){b.x("<thead>\n<tr>\n");this.aT(e,b,this.bu,"th");b.x("</tr>\n</thead>\n")}b.x("<tbody>\n");for(var c=0;c<
+this.bA.length;c++){var g=this.bA[c];b.x("<tr>\n");this.aT(e,b,g,"td");b.x("</tr>\n")}b.x("</tbody>\n");b.x("</table>\n"
+)};function av(b){b.a8();if(b.H()!="|"&&b.H()!=":"&&b.H()!="-")return null;var c=null;if(b.aW("|")){c=new H();c.ax=true}
+while(true){b.a8();if(b.H()=="|")return null;var g=b.aW(":");while(b.H()=="-")b.a5(1);var h=b.aW(":");b.a8();var e=0;if(
+g&&h)e=3;else if(g)e=1;else if(h)e=2;if(b.Y()){if(c==null)return null;c.bp.push(e);return c}if(!b.aW("|"))return null;
+if(c==null)c=new H();c.bp.push(e);b.a8();if(b.Y()){c.bk=true;return c}}}this.Markdown=i;this.HtmlTag=w})();if(typeof 
+exports!=="undefined")exports.Markdown=MarkdownDeep.Markdown

--- a/MarkdownDeepTests/JSTestResources/MarkdownDeepLib.min.js
+++ b/MarkdownDeepTests/JSTestResources/MarkdownDeepLib.min.js
@@ -6,27 +6,27 @@ if(b[c]===e)return c;return-1}function i(){this.bz=new E(this);this.bC=[];this.b
 SafeMode:false,ExtraMode:false,MarkdownInHtml:false,AutoHeadingIDs:false,UrlBaseLocation:null,UrlRootLocation:null,
 NewWindowForExternalLinks:false,NewWindowForLocalLinks:false,NoFollowLinks:false,NoFollowExternalLinks:false,
 HtmlClassFootnotes:"footnotes",HtmlClassTitledImages:null,RenderingTitledImage:false,FormatCodeBlockAttributes:null,
-FormatCodeBlock:null,ExtractHeadBlocks:false,HeadBlockContent:""};var a=i.prototype;function ao(b,c,e,g){return b.slice(
-0,c).concat(g).concat(b.slice(c+e))}i.prototype.GetListItems=function(k,n){var c=this.aE(k),b;for(b=0;b<c.length;b++){
-var e=c[b];if((e.v==23||e.v==15||e.v==22)&&e.C){c=ao(c,b,1,e.C);b--;continue}if(n<e.ay)break}b--;if(b<0)return null;var 
-h=c[b];if(h.v!=21&&h.v!=20)return null;var g=[],m=h.C;for(var j=0;j<m.length;j++)g.push(m[j].ay);b++;if(b<c.length)g.
-push(c[b].ay);else g.push(k.length);return g};i.prototype.Transform=function(c){var n=c.indexOf("\r");if(n>=0){var m=c.
-indexOf("\n");if(m>=0)if(m<n)c=c.replace(/\n\r/g,"\n");else c=c.replace(/\r\n/g,"\n");c=c.replace(/\r/g,"\n")}this.
-HeadBlockContent="";var k=this.aE(c);if(this.bn!=null){var j=[];for(var r in this.bn)j.push(this.bn[r]);j.sort(function(
-p,q){return q.Abbr.length-p.Abbr.length});this.bn=j}var b=this.bF;b.K();for(var g=0;g<k.length;g++){var s=k[g];s.l(this,
-b)}if(this.bI.length>0){b.x('\n<div class="');b.x(this.HtmlClassFootnotes);b.x('">\n');b.x("<hr />\n");b.x("<ol>\n");
-for(var g=0;g<this.bI.length;g++){var h=this.bI[g];b.x('<li id="fn:');b.x(h.X);b.x('">\n');var o='<a href="#fnref:'+h.X+
-'" rev="footnote">&#8617;</a>',e=h.C[h.C.length-1];if(e.v==12){e.v=29;e.X=o}else{e=new B();e.N=0;e.v=29;e.X=o;h.C.push(e
-)}h.l(this,b);b.x("</li>\n")}b.x("</ol>\n");b.x("</div>\n")}return b.bh()};i.prototype.OnQualifyUrl=function(b){if(au(b,
-"#"))return b;if(aj(b))return b;if(au(b,"/")){var e=this.UrlRootLocation;if(!e){if(!this.UrlBaseLocation)return b;var c=
-this.UrlBaseLocation.indexOf("://");if(c==-1)c=0;else c+=3;c=this.UrlBaseLocation.indexOf("/",c);e=c<0?this.
-UrlBaseLocation:this.UrlBaseLocation.substr(0,c)}return e+b}else{if(!this.UrlBaseLocation)return b;if(!T(this.
-UrlBaseLocation,"/"))return this.UrlBaseLocation+"/"+b;else return this.UrlBaseLocation+b}};i.prototype.OnGetImageSize=
-function(b,c){return null};i.prototype.OnPrepareLink=function(b){var c=b.attributes.href;if(this.NoFollowLinks)b.
-attributes.rel="nofollow";if(this.NoFollowExternalLinks)if(aj(c))b.attributes.rel="nofollow";if(this.
-NewWindowForExternalLinks&&aj(c)||this.NewWindowForLocalLinks&&!aj(c))b.attributes.target="_blank";b.attributes.href=
-this.OnQualifyUrl(c)};i.prototype.OnPrepareImage=function(b,e){var c=this.OnGetImageSize(b.attributes.src,e);if(c!=null)
-{b.attributes.width=c.width;b.attributes.height=c.height}b.attributes.src=this.OnQualifyUrl(b.attributes.src)};i.
+FormatCodeBlock:null,ExtractHeadBlocks:false,HeadBlockContent:"",AllowUserHtml:true};var a=i.prototype;function ao(b,c,e
+,g){return b.slice(0,c).concat(g).concat(b.slice(c+e))}i.prototype.GetListItems=function(k,n){var c=this.aE(k),b;for(b=0
+;b<c.length;b++){var e=c[b];if((e.v==23||e.v==15||e.v==22)&&e.C){c=ao(c,b,1,e.C);b--;continue}if(n<e.ay)break}b--;if(b<0
+)return null;var h=c[b];if(h.v!=21&&h.v!=20)return null;var g=[],m=h.C;for(var j=0;j<m.length;j++)g.push(m[j].ay);b++;
+if(b<c.length)g.push(c[b].ay);else g.push(k.length);return g};i.prototype.Transform=function(c){var n=c.indexOf("\r");
+if(n>=0){var m=c.indexOf("\n");if(m>=0)if(m<n)c=c.replace(/\n\r/g,"\n");else c=c.replace(/\r\n/g,"\n");c=c.replace(/\r/g
+,"\n")}this.HeadBlockContent="";var k=this.aE(c);if(this.bn!=null){var j=[];for(var r in this.bn)j.push(this.bn[r]);j.
+sort(function(p,q){return q.Abbr.length-p.Abbr.length});this.bn=j}var b=this.bF;b.K();for(var g=0;g<k.length;g++){var s=
+k[g];s.l(this,b)}if(this.bI.length>0){b.x('\n<div class="');b.x(this.HtmlClassFootnotes);b.x('">\n');b.x("<hr />\n");b.x
+("<ol>\n");for(var g=0;g<this.bI.length;g++){var h=this.bI[g];b.x('<li id="fn:');b.x(h.X);b.x('">\n');var o=
+'<a href="#fnref:'+h.X+'" rev="footnote">&#8617;</a>',e=h.C[h.C.length-1];if(e.v==12){e.v=29;e.X=o}else{e=new B();e.N=0;
+e.v=29;e.X=o;h.C.push(e)}h.l(this,b);b.x("</li>\n")}b.x("</ol>\n");b.x("</div>\n")}return b.bh()};i.prototype.
+OnQualifyUrl=function(b){if(au(b,"#"))return b;if(aj(b))return b;if(au(b,"/")){var e=this.UrlRootLocation;if(!e){if(!
+this.UrlBaseLocation)return b;var c=this.UrlBaseLocation.indexOf("://");if(c==-1)c=0;else c+=3;c=this.UrlBaseLocation.
+indexOf("/",c);e=c<0?this.UrlBaseLocation:this.UrlBaseLocation.substr(0,c)}return e+b}else{if(!this.UrlBaseLocation)
+return b;if(!T(this.UrlBaseLocation,"/"))return this.UrlBaseLocation+"/"+b;else return this.UrlBaseLocation+b}};i.
+prototype.OnGetImageSize=function(b,c){return null};i.prototype.OnPrepareLink=function(b){var c=b.attributes.href;if(
+this.NoFollowLinks)b.attributes.rel="nofollow";if(this.NoFollowExternalLinks)if(aj(c))b.attributes.rel="nofollow";if(
+this.NewWindowForExternalLinks&&aj(c)||this.NewWindowForLocalLinks&&!aj(c))b.attributes.target="_blank";b.attributes.
+href=this.OnQualifyUrl(c)};i.prototype.OnPrepareImage=function(b,e){var c=this.OnGetImageSize(b.attributes.src,e);if(c!=
+null){b.attributes.width=c.width;b.attributes.height=c.height}b.attributes.src=this.OnQualifyUrl(b.attributes.src)};i.
 prototype.GetLinkDefinition=function(b){if(this.bv.hasOwnProperty(b))return this.bv[b];else return null};a.aE=function(b
 ){this.bv=[];this.bs=[];this.bI=[];this.bJ=[];this.bn=null;return new D(this,this.MarkdownInHtml).aH(b)};a.A=function(b)
 {this.bv[b.id]=b};a.z=function(b){this.bs[b.X]=b};a.Q=function(c){var b=this.bs[c];if(b!=undefined){this.bI.push(b);
@@ -150,152 +150,152 @@ b.x("<abbr");if(e.Title){b.x(' title="');b.au(e.Title,0,e.Title.length);b.x('"')
 this.bw.am(),o=k==null?/[\*\_\`\[\!\<\&\ \\]/g:null,q=this.bw.ExtraMode,g=b.by;while(!b.J()){if(o!=null&&!b.aa(o))break;
 var m=b.by,c=null;switch(b.H()){case"*":case"_":c=this.P();if(c!=null)switch(c.type){case 13:case 11:case 12:if(h==null)
 h=[];h.push(c);break}break;case"`":c=this.aF();break;case"[":case"!":var t=b.by;c=this.aI();if(c==null)b.by=t;break;case
-"<":var e=b.by,p=ag(b);if(p!=null)if(!this.bw.SafeMode||p.at())c=this.U(1,e,b.by-e);else b.by=e;else{b.by=e;c=this.aD();
-if(c==null)b.by=e}break;case"&":var e=b.by;if(b.a6())c=this.U(2,e,b.by-e);break;case" ":if(b.F(1)==" "&&Y(b.F(2))){b.a5(
-2);if(!b.J()){b.aZ();c=this.U(8,m,0)}}break;case"\\":if(U(b.F(1),q)){c=this.U(0,b.by+1,1);b.a5(2)}break}if(c==null&&k!=
-null&&!R(b.F(-1))){var v=b.by;for(var r in k){var n=k[r];if(b.a9(n.Abbr)&&!R(b.H())){c=this.O(15,n);break}b.bK=v}}if(c!=
-null){if(m>g)j.push(this.U(0,g,m-g));j.push(c);g=b.by}else b.a5(1)}if(b.by>g)j.push(this.U(0,g,b.by-g));if(h!=null)this.
-aV(j,h)};a.P=function(){var b=this.bB,e=b.H(),k=e=="*"?"_":"*",c=b.by;if(b.D()||ad(b.F(-1))){while(ae(b.H()))b.a5(1);if(
-b.J()||ad(b.H()))return this.U(2,c,b.by-c);b.by=c}while(ae(b.F(-1)))b.a5(-1);var h=b.D()||ad(b.F(-1));b.by=c;while(b.H()
-==e)b.a5(1);var j=b.by-c;while(ae(b.F(1)))b.a5(1);var g=b.J()||ad(b.H());b.by=c+j;if(h)return this.U(11,c,b.by-c);if(g)
-return this.U(12,c,b.by-c);if(this.bw.ExtraMode&&e=="_"&&R(b.H()))return null;return this.U(13,c,b.by-c)};a.bg=function(
-h,g,b,c){var e=this.U(b.type,b.startOffset+c,b.length-c);b.length=c;g.splice(S(g,b)+1,0,e);h.splice(S(h,b)+1,0,e);
-return e};a.aV=function(n,b){var m=this.bB.E,j=true;while(j){j=false;for(var h=0;h<b.length;h++){var c=b[h];if(c.type!=
-11&&c.type!=13)continue;for(var k=h+1;k<b.length;k++){var g=b[k];if(g.type!=12&&g.type!=13)break;if(m.charAt(c.
-startOffset)!=m.charAt(g.startOffset))continue;var e=Math.min(c.length,g.length);if(e>=3)e=e%2==1?1:2;if(c.length>e){c=
-this.bg(n,b,c,c.length-e);h--}if(g.length>e)this.bg(n,b,g,e);c.type=e==1?3:5;g.type=e==1?4:6;b.splice(S(b,c),1);b.splice
-(S(b,g),1);j=true;break}}}};a.aD=function(){if(this.br)return null;var c=this.bB;c.a5(1);c.az();var j=this.bw.ExtraMode;
-while(!c.J()){var h=c.H();if(ad(h))break;if(h==">"){var b=az(c.W(),j),e=null;if(ah(b)){var g;if(b.toLowerCase().substr(0
-,7)=="mailto:")g=b.substr(7);else{g=b;b="mailto:"+b}e=new am(new C("auto",b,null),g)}else if(al(b))e=new am(new C("auto"
-,b,null),b);if(e!=null){c.a5(1);return this.O(9,e)}return null}c.a2(j)}return null};a.aI=function(){var b=this.bB,h=b.aW
-("!")?10:9;if(!b.aW("["))return null;var o=this.by;if(this.bw.ExtraMode&&h==9&&b.aW("^")){b.a8();b.az();var m=b.a4();if(
-m!=null&&b.aW("]")){var s=this.bw.Q(m);if(s>=0)return this.O(14,{index:s,id:m})}this.by=o}if(this.br&&h==9)return null;
-var r=this.bw.ExtraMode;b.az();var j=1;while(!b.J()){var p=b.H();if(p=="[")j++;else if(p=="]"){j--;if(j==0)break}b.a2(r)
-}if(b.J())return null;var n=az(b.W(),r);b.a5(1);o=b.by;if(b.aW("(")){var t=ar(b,null,this.bw.ExtraMode);if(t==null)
-return null;b.bd();if(!b.aW(")"))return null;return this.O(h,new am(t,n))}if(!b.aW(" "))b.aW("\t");if(b.Y()){b.aZ();b.a8
-()}var c=null;if(b.H()=="["){b.a5(1);b.az();if(!b.Z("]"))return null;c=b.W();b.a5(1)}else b.by=o;if(!c){c=n;while(true){
-var k=c.indexOf("\n");if(k<0)break;var g=k;while(g>0&&ad(c.charAt(g-1)))g--;var e=k;while(e<c.length&&ad(c.charAt(e)))
-e++;c=c.substr(0,g)+" "+c.substr(e)}}var q=this.bw.GetLinkDefinition(c);if(q==null)return null;return this.O(h,new am(q,
-n))};a.aF=function(){var b=this.bB,c=b.by,e=0;while(b.aW("`"))e++;b.bd();if(b.J())return this.U(0,c,b.by-c);var g=b.by;
-if(!b.Z(b.E.substr(c,e)))return this.U(0,c,b.by-c);var h=b.by+e;while(ad(b.F(-1)))b.a5(-1);var j=this.U(7,g,b.by-g);b.by
-=h;return j};a.U=function(g,e,c){if(this.bG.length!=0){var b=this.bG.pop();b.type=g;b.startOffset=e;b.length=c;b.X=null;
-return b}else return new ax(g,e,c)};a.O=function(e,c){if(this.bG.length!=0){var b=this.bG.pop();b.type=e;b.X=c;return b}
-else{var b=new ax(e,0,0);b.X=c;return b}};a.ak=function(b){b.X=null;this.bG.push(b)};function B(){}a=B.prototype;a.E=
-null;a.v=0;a.R=0;a.N=0;a.ay=0;a.aA=0;a.C=null;a.X=null;a.an=function(){if(this.E==null)return null;if(this.R==-1)
-return this.E;return this.E.substr(this.R,this.N)};a.al=function(){var c=new F();for(var b=0;b<this.C.length;b++){c.x(
-this.C[b].an());c.x("\n")}return c.bh()};a.aN=function(e,c){for(var b=0;b<this.C.length;b++)this.C[b].l(e,c)};a.aX=
-function(e){if(typeof this.X=="string")return this.X;var c=at(this.E,this.R,this.ao()),b=null;if(c!=null){this.a3(c.end)
-;b=c.id}else b=e.aC(this.E,this.R,this.N);this.X=b;return b};a.l=function(c,b){switch(this.v){case 0:return;case 12:c.bz
-.ah(b,this.E,this.R,this.N);break;case 17:c.bz.ae(b,this.E,this.R,this.N);b.x("\n");break;case 1:case 2:case 3:case 4:
-case 5:case 6:if(c.ExtraMode&&!c.SafeMode){b.x("<h"+(this.v-1+1).toString());var k=this.aX(c);if(k){b.x(' id="');b.x(k);
-b.x('">')}else b.x(">")}else b.x("<h"+(this.v-1+1).toString()+">");c.bz.ae(b,this.E,this.R,this.N);b.x("</h"+(this.v-1+1
-).toString()+">\n");break;case 14:b.x("<hr />\n");return;case 10:case 11:b.x("<li>");c.bz.ae(b,this.E,this.R,this.N);b.x
-("</li>\n");break;case 15:b.x(this.E.substr(this.R,this.N));return;case 16:b.au(this.E,this.R,this.N);return;case 18:b.x
-("<pre");if(c.FormatCodeBlockAttributes!=null)b.x(c.FormatCodeBlockAttributes(this.X));b.x("><code>");var h=b;if(c.
-FormatCodeBlock){h=b;b=new F()}for(var e=0;e<this.C.length;e++){var j=this.C[e];b.av(j.E,j.R,j.N);b.x("\n")}if(c.
-FormatCodeBlock){h.x(c.FormatCodeBlock(b.bh(),this.X));b=h}b.x("</code></pre>\n\n");return;case 9:b.x("<blockquote>\n");
-this.aN(c,b);b.x("</blockquote>\n");return;case 19:b.x("<li>\n");this.aN(c,b);b.x("</li>\n");return;case 20:b.x("<ol>\n"
-);this.aN(c,b);b.x("</ol>\n");return;case 21:b.x("<ul>\n");this.aN(c,b);b.x("</ul>\n");return;case 22:var g=this.X,n=g.
-name.toLowerCase();if(n=="a")c.OnPrepareLink(g);else if(n=="img")c.OnPrepareImage(g,c.RenderingTitledImage);g.aS(b);b.x(
-"\n");this.aN(c,b);g.aO(b);b.x("\n");return;case 23:case 28:this.aN(c,b);return;case 24:this.X.l(c,b);return;case 25:b.x
-("<dd>");if(this.C!=null){b.x("\n");this.aN(c,b)}else c.bz.ae(b,this.E,this.R,this.N);b.x("</dd>\n");break;case 26:if(
-this.C==null){var m=this.an().split("\n");for(var e=0;e<m.length;e++){var o=m[e];b.x("<dt>");c.bz.af(b,ay(o));b.x(
-"</dt>\n")}}else{b.x("<dt>\n");this.aN(c,b);b.x("</dt>\n")}break;case 27:b.x("<dl>\n");this.aN(c,b);b.x("</dl>\n");
-return;case 29:b.x("<p>");if(this.N>0){c.bz.ae(b,this.E,this.R,this.N);b.x("&nbsp;")}b.x(this.X);b.x("</p>\n");break}};a
-.aY=function(){this.v=12;this.R=this.ay;this.N=this.aA};a.ao=function(){return this.R+this.N};a.a3=function(b){this.N=b-
-this.R};a.aq=function(){var c=0;for(var b=this.ay;b<this.ay+this.aA;b++)if(this.E.charAt(b)==" ")c++;else break;return c
-};a.V=function(b){this.v=b.v;this.E=b.E;this.R=b.R;this.N=b.N;this.ay=b.ay;this.aA=b.aA;return this};function D(b,c){
-this.bw=b;this.bx=0;this.bo=c}a=D.prototype;a.aH=function(c){var b=new G(c);return this.a1(b)};a.aL=function(g,e,b){var 
-c=new G(g,e,b);return this.a1(c)};a.bi=function(b,c,e){if(e.length>1)return false;if(e.length==1){var g=b.by;b.by=e[0].
-ay;c.bu=c.aG(b);if(c.bu==null)return false;b.by=g;e.length=0}while(true){var g=b.by,h=c.aG(b);if(h!=null){c.bA.push(h);
-continue}b.by=g;break}return true};a.a1=function(j){var e=[],c=[],k=-1;while(!j.J()){var m=k==0,b=this.ab(j);k=b.v;if(b.
-v==25)b.X=m;if(b.v==7||b.v==8){if(c.length>0){var g=c.pop();this.S(e,c);if(g.v!=0){g.aY();g.v=b.v==7?1:2;e.push(g);
-continue}}if(b.v==7){b.aY();c.push(b)}else if(b.N>=3){b.v=14;e.push(b)}else{b.aY();c.push(b)}continue}var h=c.length>0?c
-[0].v:0;if(b.v==24){var o=b.X,n=j.by;if(!this.bi(j,o,c)){j.by=n;b.aY()}else{e.push(b);continue}}switch(b.v){case 0:
-switch(h){case 0:this.ai(b);break;case 12:this.S(e,c);this.ai(b);break;case 9:case 10:case 11:case 25:case 28:case 13:c.
-push(b);break}break;case 12:switch(h){case 0:case 12:c.push(b);break;case 9:case 10:case 11:case 25:case 28:var g=c[c.
-length-1];if(g.v==0){this.S(e,c);c.push(b)}else c.push(b);break;case 13:this.S(e,c);c.push(b);break}break;case 13:
-switch(h){case 0:c.push(b);break;case 12:case 9:var g=c[c.length-1];if(g.v==0){this.S(e,c);c.push(b)}else{b.aY();c.push(
-b)}break;case 10:case 11:case 13:case 25:case 28:c.push(b);break}break;case 9:if(h!=9)this.S(e,c);c.push(b);break;case 
-10:case 11:switch(h){case 0:c.push(b);break;case 12:case 9:var g=c[c.length-1];if(g.v==0||this.bx==10||this.bx==11||this
-.bx==25){this.S(e,c);c.push(b)}else{b.aY();c.push(b)}break;case 10:case 11:if(b.v!=10&&b.v!=11)this.S(e,c);c.push(b);
-break;case 25:case 28:if(b.v!=h)this.S(e,c);c.push(b);break;case 13:this.S(e,c);c.push(b);break}break;case 25:case 28:
-switch(h){case 0:case 12:case 25:case 28:this.S(e,c);c.push(b);break;default:b.aY();c.push(b);break}break;default:this.S
-(e,c);e.push(b);break}}this.S(e,c);if(this.bw.ExtraMode)this.I(e);return e};a.T=function(c){var b;if(this.bw.bC.length>1
-)b=this.bw.bC.pop();else b=new B();b.ay=c;return b};a.ai=function(b){this.bw.bC.push(b)};a.aj=function(b){for(var c=0;c<
-b.length;c++)this.bw.bC.push(b[c]);b.length=0};a.aQ=function(g){var b=this.bw.as();for(var c=0;c<g.length;c++){var e=g[c
-];b.x(e.E.substr(e.R,e.N));b.x("\n")}return b.bh()};a.S=function(c,b){while(b.length>0&&b[b.length-1].v==0)this.ai(b.pop
-());if(b.length==0)return;switch(b[0].v){case 12:var h=this.T(b[0].ay);h.v=12;h.E=b[0].E;h.R=b[0].R;h.a3(b[b.length-1].
-ao());c.push(h);this.aj(b);break;case 9:var p=this.aQ(b),o=new D(this.bw,this.bo);o.bx=9;var n=this.T(b[0].ay);n.v=9;n.C
-=o.aH(p);this.aj(b);c.push(n);break;case 10:case 11:c.push(this.M(b));break;case 25:if(c.length>0){var j=c[c.length-1];
-switch(j.v){case 12:j.v=26;break;case 25:break;default:var k=this.T(j.ay);k.v=26;k.C=[];k.C.push(j);c.pop();c.push(k);
-break}}c.push(this.G(b));break;case 28:this.bw.z(this.L(b));break;case 13:var e=this.T(b[0].ay);e.v=18;e.C=[];var g=b[0]
-.an();if(g.substr(0,2)=="{{"&&g.substr(g.length-2,2)=="}}"){e.X=g.substr(2,g.length-4);b.splice(0,1)}for(var m=0;m<b.
-length;m++)e.C.push(b[m]);c.push(e);b.length=0;break}};a.ab=function(c){var b=this.T(c.by);b.E=c.E;b.R=c.by;b.N=-1;b.v=
-this.ac(c,b);if(b.N<0){c.bb();b.N=c.by-b.R}b.aA=c.by-b.ay;c.aZ();return b};a.ac=function(b,c){if(b.Y())return 0;var h=b.
-by,e=b.H();if(e=="#"){var j=1;b.a5(1);while(b.H()=="#"){j++;b.a5(1)}if(j>6)j=6;b.a8();c.R=b.by;b.bb();if(this.bw.
-ExtraMode&&!this.bw.SafeMode){var m=at(b.E,c.R,b.by);if(m!=null){c.X=m.id;b.by=m.end}}while(b.by>c.R&&b.F(-1)=="#")b.a5(
--1);while(b.by>c.R&&ad(b.F(-1)))b.a5(-1);c.N=b.by-c.R;b.bb();return 1+j-1}if(e=="-"||e=="="){var k=e;while(b.H()==k)b.a5
-(1);b.a8();if(b.Y())return k=="="?7:8;b.by=h}if(this.bw.ExtraMode){var s=av(b);if(s!=null){c.X=s;return 24}b.by=h;if(e==
-"~"||e=="`"){if(this.aJ(b,c))return c.v;b.by=h}}var g=-1,r=0;while(!b.Y()){if(b.H()==" "){if(g<0)r++}else if(b.H()=="\t"
-){if(g<0)g=b.by}else break;b.a5(1)}if(b.Y()){c.N=0;return 0}if(r>=4){c.R=h+4;return 13}if(g>=0&&g-h<4){c.R=g+1;return 13
-}c.R=b.by;e=b.H();if(e=="<"){if(this.a0(b,c))return c.v;b.by=c.R}if(e==">"){if(ab(b.F(1))){b.a5(2);c.R=b.by;return 9}b.
-a5(1);c.R=b.by;return 9}if(e=="-"||e=="_"||e=="*"){var o=0;while(!b.Y()){var k=b.H();if(b.H()==e){o++;b.a5(1);continue}
-if(ab(b.H())){b.a5(1);continue}break}if(b.Y()&&o>=3)return 14;b.by=c.R}if(this.bw.ExtraMode&&e=="*"&&b.F(1)=="["){b.a5(2
-);b.a8();b.az();while(!b.Y()&&b.H()!="]")b.a5(1);var n=ay(b.W());if(b.H()=="]"&&b.F(1)==":"&&n){b.a5(2);b.a8();b.az();b.
-bb();var v=b.W();this.bw.y(n,v);return 0}b.by=c.R}if((e=="*"||e=="+"||e=="-")&&ab(b.F(1))){b.a5(1);b.a8();c.R=b.by;
-return 11}if(e==":"&&this.bw.ExtraMode&&ab(b.F(1))){b.a5(1);b.a8();c.R=b.by;return 25}if(X(e)){b.a5(1);while(X(b.H()))b.
-a5(1);if(b.aW(".")&&b.a8()){c.R=b.by;return 10}b.by=c.R}if(e=="["){if(this.bw.ExtraMode&&b.F(1)=="^"){var t=b.by;b.a5(2)
-;var p=b.a4();if(p!=null&&b.aW("]")&&b.aW(":")){b.a8();c.R=b.by;c.X=p;return 28}b.by=t}var q=an(b,this.bw.ExtraMode);if(
-q!=null){this.bw.A(q);return 0}}return 12};a.ar=function(c){var b=c.attributes.markdown;if(b==undefined)if(this.bo)
-return 3;else return 0;delete c.attributes.markdown;if(b=="1")return(c.ap()&8)!=0?2:1;if(b=="block")return 1;if(b==
-"deep")return 3;if(b=="span")return 2;return 4};a.aK=function(b,e,o,m){var g=b.by,k=1,j=false;while(!b.J()){if(!b.Z("<")
-)break;var n=b.by,h=ag(b);if(h==null){b.a5(1);continue}if(this.bw.SafeMode&&m==4&&!j)if(!h.at())j=true;if(h.closed)
-continue;if(h.name==o.name)if(h.closing){k--;if(k==0){b.a8();b.aZ();e.v=22;e.X=o;e.a3(b.by);switch(m){case 2:var c=this.
-T(g);c.E=b.E;c.v=17;c.R=g;c.N=n-g;e.C=[];e.C.push(c);break;case 1:case 3:var p=new D(this.bw,m==3);e.C=p.aL(b.E,g,n-g);
-break;case 4:if(j){e.v=16;e.a3(b.by)}else{var c=this.T(g);c.E=b.E;c.v=15;c.R=g;c.N=n-g;e.C=[];e.C.push(c)}break}
-return true}}else k++}return false};a.a0=function(b,c){var g=b.by,h=ag(b);if(h==null)return false;if(h.closing)
-return false;var m=false;if(this.bw.SafeMode&&!h.at())m=true;var q=h.ap();if((q&1)==0)return false;if((q&4)!=0||h.closed
-){b.a8();b.aZ();c.N=b.by-c.R;c.v=m?16:15;return true}if((q&2)!=0){b.a8();if(!b.Y())return false}var o=this.bw.
-ExtractHeadBlocks&&h.name.toLowerCase()=="head",t=b.by;if(!o&&this.bw.ExtraMode){var n=this.ar(h);if(n!=0)return this.aK
-(b,c,h,n)}var k=null,p=1;while(!b.J()){if(!b.Z("<"))break;var s=b.by,j=ag(b);if(j==null){b.a5(1);continue}if(this.bw.
-SafeMode&&!j.at())m=true;if(j.closed)continue;if(!o&&!j.closing&&this.bw.ExtraMode&&!m){var n=this.ar(j);if(n!=0){var r=
-this.T(g);if(this.aK(b,r,j,n)){if(k==null)k=[];if(s>g){var e=this.T(g);e.E=b.E;e.v=15;e.R=g;e.N=s-g;k.push(e)}k.push(r);
-g=b.by;continue}else this.ai(r)}}if(j.name==h.name&&!j.closed)if(j.closing){p--;if(p==0){b.a8();b.aZ();if(m){c.v=16;c.a3
-(b.by);return true}if(k!=null){if(b.by>g){var e=this.T(g);e.E=b.E;e.v=15;e.R=g;e.N=b.by-g;k.push(e)}c.v=23;c.a3(b.by);c.
-C=k;return true}if(o){var v=b.E.substr(t,s-t);this.bw.HeadBlockContent=this.bw.HeadBlockContent+ay(v)+"\n";c.v=15;c.R=b.
-bK;c.contentEnd=b.bK;c.ay=b.bK;return true}c.v=15;c.N=b.by-c.R;return true}}else p++}return 0};a.M=function(b){var r=b[0
-].v,t=b[0].aq();for(var c=1;c<b.length;c++){if(b[c].v==12&&(b[c-1].v==12||b[c-1].v==11||b[c-1].v==10)){b[c-1].a3(b[c].ao
-());this.ai(b[c]);b.splice(c,1);c--;continue}if(b[c].v!=13&&b[c].v!=0){var s=b[c].aq();if(s>t){b[c].v=13;var v=b[c].ao()
-;b[c].R=b[c].ay+s;b[c].a3(v)}}}var h=this.T(0);h.v=r==11?21:20;h.C=[];for(var c=0;c<b.length;c++){var k=c;while(k>0&&b[k
--1].v==0)k--;var g=c;while(g<b.length-1&&b[g+1].v!=11&&b[g+1].v!=10)g++;if(k==g)h.C.push(this.T().V(b[c]));else{var o=
-false,n=this.bw.as();for(var e=k;e<=g;e++){var m=b[e];n.x(m.E.substr(m.R,m.N));n.x("\n");if(b[e].v==0)o=true}var j=this.
-T();j.v=19;j.ay=b[k].ay;var p=new D(this.bw);p.bx=r;j.C=p.aH(n.bh());if(!o)for(var e=0;e<j.C.length;e++){var q=j.C[e];
-if(q.v==12)q.v=17}h.C.push(j)}c=g}h.ay=h.C[0].ay;this.aj(b);b.length=0;return h};a.G=function(b){for(var c=1;c<b.length;
-c++)if(b[c].v==12&&(b[c-1].v==12||b[c-1].v==25)){b[c-1].a3(b[c].ao());this.ai(b[c]);b.splice(c,1);c--;continue}var k=b[0
-].X;if(b.length==1&&!k){var m=b[0];b.length=0;return m}var h=this.bw.as();for(var c=0;c<b.length;c++){var g=b[c];h.x(g.E
-.substr(g.R,g.N));h.x("\n")}var e=this.T(b[0].ay);e.v=25;var j=new D(this.bw);j.bx=25;e.C=j.aH(h.bh());this.aj(b);b.
-length=0;return e};a.I=function(e){var c=null;for(var b=0;b<e.length;b++)switch(e[b].v){case 26:case 25:if(c==null){c=
-this.T(e[b].ay);c.v=27;c.C=[];e.splice(b,0,c);b++}c.C.push(e[b]);e.splice(b,1);b--;break;default:c=null;break}};a.L=
-function(c){for(var b=1;b<c.length;b++)if(c[b].v==12&&(c[b-1].v==12||c[b-1].v==28)){c[b-1].a3(c[b].ao());this.ai(c[b]);c
-.splice(b,1);b--;continue}var h=this.bw.as();for(var b=0;b<c.length;b++){var g=c[b];h.x(g.E.substr(g.R,g.N));h.x("\n")}
-var j=new D(this.bw);j.bx=28;var e=this.T(c[0].ay);e.v=28;e.X=c[0].X;e.C=j.aH(h.bh());this.aj(c);c.length=0;return e};a.
-aJ=function(b,e){var m=b.by,k=b.H();b.az();while(b.H()==k)b.a5(1);var g=b.W();if(g.length<3)return false;b.a8();if(!b.Y(
-))return false;b.aZ();var j=b.by;if(!b.Z(g))return false;if(!Y(b.F(-1)))return false;var h=b.by;b.a5(g.length);b.a8();
-if(!b.Y())return false;e.v=18;e.C=[];h--;var c=this.T(m);c.v=13;c.E=b.E;c.R=j;c.N=h-j;e.C.push(c);return true};function 
-H(){this.bp=[];this.bu=null;this.bA=[]}a=H.prototype;a.ax=false;a.bk=false;a.aG=function(b){b.a8();if(b.Y())return null;
-var e=this.ax;if(this.ax&&!b.aW("|")){e=true;return null}var c=[];while(!b.Y()){b.az();while(!b.Y()&&b.H()!="|")b.a2(
-true);c.push(ay(b.W()));e|=b.aW("|")}if(!e)return null;while(c.length<this.bp.length)c.push("&nbsp;");b.aZ();return c};a
-.aT=function(h,b,e,g){for(var c=0;c<e.length;c++){b.x("\t<");b.x(g);if(c<this.bp.length)switch(this.bp[c]){case 1:b.x(
-' align="left"');break;case 2:b.x(' align="right"');break;case 3:b.x(' align="center"');break}b.x(">");h.bz.af(b,e[c]);b
-.x("</");b.x(g);b.x(">\n")}};a.l=function(e,b){b.x("<table>\n");if(this.bu!=null){b.x("<thead>\n<tr>\n");this.aT(e,b,
-this.bu,"th");b.x("</tr>\n</thead>\n")}b.x("<tbody>\n");for(var c=0;c<this.bA.length;c++){var g=this.bA[c];b.x("<tr>\n")
-;this.aT(e,b,g,"td");b.x("</tr>\n")}b.x("</tbody>\n");b.x("</table>\n")};function av(b){b.a8();if(b.H()!="|"&&b.H()!=":"
-&&b.H()!="-")return null;var c=null;if(b.aW("|")){c=new H();c.ax=true}while(true){b.a8();if(b.H()=="|")return null;var g
-=b.aW(":");while(b.H()=="-")b.a5(1);var h=b.aW(":");b.a8();var e=0;if(g&&h)e=3;else if(g)e=1;else if(h)e=2;if(b.Y()){if(
-c==null)return null;c.bp.push(e);return c}if(!b.aW("|"))return null;if(c==null)c=new H();c.bp.push(e);b.a8();if(b.Y()){c
-.bk=true;return c}}}this.Markdown=i;this.HtmlTag=w})();if(typeof exports!=="undefined")exports.Markdown=MarkdownDeep.
-Markdown;
+"<":var e=b.by,p=ag(b);if(p!=null)if((!this.bw.SafeMode||p.at())&&this.bw.AllowUserHtml)c=this.U(1,e,b.by-e);else b.by=e
+;else{b.by=e;c=this.aD();if(c==null)b.by=e}break;case"&":var e=b.by;if(b.a6())c=this.U(2,e,b.by-e);break;case" ":if(b.F(
+1)==" "&&Y(b.F(2))){b.a5(2);if(!b.J()){b.aZ();c=this.U(8,m,0)}}break;case"\\":if(U(b.F(1),q)){c=this.U(0,b.by+1,1);b.a5(
+2)}break}if(c==null&&k!=null&&!R(b.F(-1))){var v=b.by;for(var r in k){var n=k[r];if(b.a9(n.Abbr)&&!R(b.H())){c=this.O(15
+,n);break}b.bK=v}}if(c!=null){if(m>g)j.push(this.U(0,g,m-g));j.push(c);g=b.by}else b.a5(1)}if(b.by>g)j.push(this.U(0,g,b
+.by-g));if(h!=null)this.aV(j,h)};a.P=function(){var b=this.bB,e=b.H(),k=e=="*"?"_":"*",c=b.by;if(b.D()||ad(b.F(-1))){
+while(ae(b.H()))b.a5(1);if(b.J()||ad(b.H()))return this.U(2,c,b.by-c);b.by=c}while(ae(b.F(-1)))b.a5(-1);var h=b.D()||ad(
+b.F(-1));b.by=c;while(b.H()==e)b.a5(1);var j=b.by-c;while(ae(b.F(1)))b.a5(1);var g=b.J()||ad(b.H());b.by=c+j;if(h)
+return this.U(11,c,b.by-c);if(g)return this.U(12,c,b.by-c);if(this.bw.ExtraMode&&e=="_"&&R(b.H()))return null;
+return this.U(13,c,b.by-c)};a.bg=function(h,g,b,c){var e=this.U(b.type,b.startOffset+c,b.length-c);b.length=c;g.splice(S
+(g,b)+1,0,e);h.splice(S(h,b)+1,0,e);return e};a.aV=function(n,b){var m=this.bB.E,j=true;while(j){j=false;for(var h=0;h<b
+.length;h++){var c=b[h];if(c.type!=11&&c.type!=13)continue;for(var k=h+1;k<b.length;k++){var g=b[k];if(g.type!=12&&g.
+type!=13)break;if(m.charAt(c.startOffset)!=m.charAt(g.startOffset))continue;var e=Math.min(c.length,g.length);if(e>=3)e=
+e%2==1?1:2;if(c.length>e){c=this.bg(n,b,c,c.length-e);h--}if(g.length>e)this.bg(n,b,g,e);c.type=e==1?3:5;g.type=e==1?4:6
+;b.splice(S(b,c),1);b.splice(S(b,g),1);j=true;break}}}};a.aD=function(){if(this.br)return null;var c=this.bB;c.a5(1);c.
+az();var j=this.bw.ExtraMode;while(!c.J()){var h=c.H();if(ad(h))break;if(h==">"){var b=az(c.W(),j),e=null;if(ah(b)){var 
+g;if(b.toLowerCase().substr(0,7)=="mailto:")g=b.substr(7);else{g=b;b="mailto:"+b}e=new am(new C("auto",b,null),g)}else 
+if(al(b))e=new am(new C("auto",b,null),b);if(e!=null){c.a5(1);return this.O(9,e)}return null}c.a2(j)}return null};a.aI=
+function(){var b=this.bB,h=b.aW("!")?10:9;if(!b.aW("["))return null;var o=this.by;if(this.bw.ExtraMode&&h==9&&b.aW("^"))
+{b.a8();b.az();var m=b.a4();if(m!=null&&b.aW("]")){var s=this.bw.Q(m);if(s>=0)return this.O(14,{index:s,id:m})}this.by=o
+}if(this.br&&h==9)return null;var r=this.bw.ExtraMode;b.az();var j=1;while(!b.J()){var p=b.H();if(p=="[")j++;else if(p==
+"]"){j--;if(j==0)break}b.a2(r)}if(b.J())return null;var n=az(b.W(),r);b.a5(1);o=b.by;if(b.aW("(")){var t=ar(b,null,this.
+bw.ExtraMode);if(t==null)return null;b.bd();if(!b.aW(")"))return null;return this.O(h,new am(t,n))}if(!b.aW(" "))b.aW(
+"\t");if(b.Y()){b.aZ();b.a8()}var c=null;if(b.H()=="["){b.a5(1);b.az();if(!b.Z("]"))return null;c=b.W();b.a5(1)}else b.
+by=o;if(!c){c=n;while(true){var k=c.indexOf("\n");if(k<0)break;var g=k;while(g>0&&ad(c.charAt(g-1)))g--;var e=k;while(e<
+c.length&&ad(c.charAt(e)))e++;c=c.substr(0,g)+" "+c.substr(e)}}var q=this.bw.GetLinkDefinition(c);if(q==null)return null
+;return this.O(h,new am(q,n))};a.aF=function(){var b=this.bB,c=b.by,e=0;while(b.aW("`"))e++;b.bd();if(b.J())return this.
+U(0,c,b.by-c);var g=b.by;if(!b.Z(b.E.substr(c,e)))return this.U(0,c,b.by-c);var h=b.by+e;while(ad(b.F(-1)))b.a5(-1);var 
+j=this.U(7,g,b.by-g);b.by=h;return j};a.U=function(g,e,c){if(this.bG.length!=0){var b=this.bG.pop();b.type=g;b.
+startOffset=e;b.length=c;b.X=null;return b}else return new ax(g,e,c)};a.O=function(e,c){if(this.bG.length!=0){var b=this
+.bG.pop();b.type=e;b.X=c;return b}else{var b=new ax(e,0,0);b.X=c;return b}};a.ak=function(b){b.X=null;this.bG.push(b)};
+function B(){}a=B.prototype;a.E=null;a.v=0;a.R=0;a.N=0;a.ay=0;a.aA=0;a.C=null;a.X=null;a.an=function(){if(this.E==null)
+return null;if(this.R==-1)return this.E;return this.E.substr(this.R,this.N)};a.al=function(){var c=new F();for(var b=0;b
+<this.C.length;b++){c.x(this.C[b].an());c.x("\n")}return c.bh()};a.aN=function(e,c){for(var b=0;b<this.C.length;b++)this
+.C[b].l(e,c)};a.aX=function(e){if(typeof this.X=="string")return this.X;var c=at(this.E,this.R,this.ao()),b=null;if(c!=
+null){this.a3(c.end);b=c.id}else b=e.aC(this.E,this.R,this.N);this.X=b;return b};a.l=function(c,b){switch(this.v){case 0
+:return;case 12:c.bz.ah(b,this.E,this.R,this.N);break;case 17:c.bz.ae(b,this.E,this.R,this.N);b.x("\n");break;case 1:
+case 2:case 3:case 4:case 5:case 6:if(c.ExtraMode&&!c.SafeMode){b.x("<h"+(this.v-1+1).toString());var k=this.aX(c);if(k)
+{b.x(' id="');b.x(k);b.x('">')}else b.x(">")}else b.x("<h"+(this.v-1+1).toString()+">");c.bz.ae(b,this.E,this.R,this.N);
+b.x("</h"+(this.v-1+1).toString()+">\n");break;case 14:b.x("<hr />\n");return;case 10:case 11:b.x("<li>");c.bz.ae(b,this
+.E,this.R,this.N);b.x("</li>\n");break;case 15:b.x(this.E.substr(this.R,this.N));return;case 16:b.au(this.E,this.R,this.
+N);return;case 18:b.x("<pre");if(c.FormatCodeBlockAttributes!=null)b.x(c.FormatCodeBlockAttributes(this.X));b.x(
+"><code>");var h=b;if(c.FormatCodeBlock){h=b;b=new F()}for(var e=0;e<this.C.length;e++){var j=this.C[e];b.av(j.E,j.R,j.N
+);b.x("\n")}if(c.FormatCodeBlock){h.x(c.FormatCodeBlock(b.bh(),this.X));b=h}b.x("</code></pre>\n\n");return;case 9:b.x(
+"<blockquote>\n");this.aN(c,b);b.x("</blockquote>\n");return;case 19:b.x("<li>\n");this.aN(c,b);b.x("</li>\n");return;
+case 20:b.x("<ol>\n");this.aN(c,b);b.x("</ol>\n");return;case 21:b.x("<ul>\n");this.aN(c,b);b.x("</ul>\n");return;case 
+22:var g=this.X,n=g.name.toLowerCase();if(n=="a")c.OnPrepareLink(g);else if(n=="img")c.OnPrepareImage(g,c.
+RenderingTitledImage);g.aS(b);b.x("\n");this.aN(c,b);g.aO(b);b.x("\n");return;case 23:case 28:this.aN(c,b);return;case 
+24:this.X.l(c,b);return;case 25:b.x("<dd>");if(this.C!=null){b.x("\n");this.aN(c,b)}else c.bz.ae(b,this.E,this.R,this.N)
+;b.x("</dd>\n");break;case 26:if(this.C==null){var m=this.an().split("\n");for(var e=0;e<m.length;e++){var o=m[e];b.x(
+"<dt>");c.bz.af(b,ay(o));b.x("</dt>\n")}}else{b.x("<dt>\n");this.aN(c,b);b.x("</dt>\n")}break;case 27:b.x("<dl>\n");this
+.aN(c,b);b.x("</dl>\n");return;case 29:b.x("<p>");if(this.N>0){c.bz.ae(b,this.E,this.R,this.N);b.x("&nbsp;")}b.x(this.X)
+;b.x("</p>\n");break}};a.aY=function(){this.v=12;this.R=this.ay;this.N=this.aA};a.ao=function(){return this.R+this.N};a.
+a3=function(b){this.N=b-this.R};a.aq=function(){var c=0;for(var b=this.ay;b<this.ay+this.aA;b++)if(this.E.charAt(b)==" "
+)c++;else break;return c};a.V=function(b){this.v=b.v;this.E=b.E;this.R=b.R;this.N=b.N;this.ay=b.ay;this.aA=b.aA;
+return this};function D(b,c){this.bw=b;this.bx=0;this.bo=c}a=D.prototype;a.aH=function(c){var b=new G(c);return this.a1(
+b)};a.aL=function(g,e,b){var c=new G(g,e,b);return this.a1(c)};a.bi=function(b,c,e){if(e.length>1)return false;if(e.
+length==1){var g=b.by;b.by=e[0].ay;c.bu=c.aG(b);if(c.bu==null)return false;b.by=g;e.length=0}while(true){var g=b.by,h=c.
+aG(b);if(h!=null){c.bA.push(h);continue}b.by=g;break}return true};a.a1=function(j){var e=[],c=[],k=-1;while(!j.J()){var 
+m=k==0,b=this.ab(j);k=b.v;if(b.v==25)b.X=m;if(b.v==7||b.v==8){if(c.length>0){var g=c.pop();this.S(e,c);if(g.v!=0){g.aY()
+;g.v=b.v==7?1:2;e.push(g);continue}}if(b.v==7){b.aY();c.push(b)}else if(b.N>=3){b.v=14;e.push(b)}else{b.aY();c.push(b)}
+continue}var h=c.length>0?c[0].v:0;if(b.v==24){var o=b.X,n=j.by;if(!this.bi(j,o,c)){j.by=n;b.aY()}else{e.push(b);
+continue}}switch(b.v){case 0:switch(h){case 0:this.ai(b);break;case 12:this.S(e,c);this.ai(b);break;case 9:case 10:case 
+11:case 25:case 28:case 13:c.push(b);break}break;case 12:switch(h){case 0:case 12:c.push(b);break;case 9:case 10:case 11
+:case 25:case 28:var g=c[c.length-1];if(g.v==0){this.S(e,c);c.push(b)}else c.push(b);break;case 13:this.S(e,c);c.push(b)
+;break}break;case 13:switch(h){case 0:c.push(b);break;case 12:case 9:var g=c[c.length-1];if(g.v==0){this.S(e,c);c.push(b
+)}else{b.aY();c.push(b)}break;case 10:case 11:case 13:case 25:case 28:c.push(b);break}break;case 9:if(h!=9)this.S(e,c);c
+.push(b);break;case 10:case 11:switch(h){case 0:c.push(b);break;case 12:case 9:var g=c[c.length-1];if(g.v==0||this.bx==
+10||this.bx==11||this.bx==25){this.S(e,c);c.push(b)}else{b.aY();c.push(b)}break;case 10:case 11:if(b.v!=10&&b.v!=11)this
+.S(e,c);c.push(b);break;case 25:case 28:if(b.v!=h)this.S(e,c);c.push(b);break;case 13:this.S(e,c);c.push(b);break}break;
+case 25:case 28:switch(h){case 0:case 12:case 25:case 28:this.S(e,c);c.push(b);break;default:b.aY();c.push(b);break}
+break;default:this.S(e,c);e.push(b);break}}this.S(e,c);if(this.bw.ExtraMode)this.I(e);return e};a.T=function(c){var b;
+if(this.bw.bC.length>1)b=this.bw.bC.pop();else b=new B();b.ay=c;return b};a.ai=function(b){this.bw.bC.push(b)};a.aj=
+function(b){for(var c=0;c<b.length;c++)this.bw.bC.push(b[c]);b.length=0};a.aQ=function(g){var b=this.bw.as();for(var c=0
+;c<g.length;c++){var e=g[c];b.x(e.E.substr(e.R,e.N));b.x("\n")}return b.bh()};a.S=function(c,b){while(b.length>0&&b[b.
+length-1].v==0)this.ai(b.pop());if(b.length==0)return;switch(b[0].v){case 12:var h=this.T(b[0].ay);h.v=12;h.E=b[0].E;h.R
+=b[0].R;h.a3(b[b.length-1].ao());c.push(h);this.aj(b);break;case 9:var p=this.aQ(b),o=new D(this.bw,this.bo);o.bx=9;var 
+n=this.T(b[0].ay);n.v=9;n.C=o.aH(p);this.aj(b);c.push(n);break;case 10:case 11:c.push(this.M(b));break;case 25:if(c.
+length>0){var j=c[c.length-1];switch(j.v){case 12:j.v=26;break;case 25:break;default:var k=this.T(j.ay);k.v=26;k.C=[];k.
+C.push(j);c.pop();c.push(k);break}}c.push(this.G(b));break;case 28:this.bw.z(this.L(b));break;case 13:var e=this.T(b[0].
+ay);e.v=18;e.C=[];var g=b[0].an();if(g.substr(0,2)=="{{"&&g.substr(g.length-2,2)=="}}"){e.X=g.substr(2,g.length-4);b.
+splice(0,1)}for(var m=0;m<b.length;m++)e.C.push(b[m]);c.push(e);b.length=0;break}};a.ab=function(c){var b=this.T(c.by);b
+.E=c.E;b.R=c.by;b.N=-1;b.v=this.ac(c,b);if(b.N<0){c.bb();b.N=c.by-b.R}b.aA=c.by-b.ay;c.aZ();return b};a.ac=function(b,c)
+{if(b.Y())return 0;var h=b.by,e=b.H();if(e=="#"){var j=1;b.a5(1);while(b.H()=="#"){j++;b.a5(1)}if(j>6)j=6;b.a8();c.R=b.
+by;b.bb();if(this.bw.ExtraMode&&!this.bw.SafeMode){var m=at(b.E,c.R,b.by);if(m!=null){c.X=m.id;b.by=m.end}}while(b.by>c.
+R&&b.F(-1)=="#")b.a5(-1);while(b.by>c.R&&ad(b.F(-1)))b.a5(-1);c.N=b.by-c.R;b.bb();return 1+j-1}if(e=="-"||e=="="){var k=
+e;while(b.H()==k)b.a5(1);b.a8();if(b.Y())return k=="="?7:8;b.by=h}if(this.bw.ExtraMode){var s=av(b);if(s!=null){c.X=s;
+return 24}b.by=h;if(e=="~"||e=="`"){if(this.aJ(b,c))return c.v;b.by=h}}var g=-1,r=0;while(!b.Y()){if(b.H()==" "){if(g<0)
+r++}else if(b.H()=="\t"){if(g<0)g=b.by}else break;b.a5(1)}if(b.Y()){c.N=0;return 0}if(r>=4){c.R=h+4;return 13}if(g>=0&&g
+-h<4){c.R=g+1;return 13}c.R=b.by;e=b.H();if(e=="<"){if(this.a0(b,c))return c.v;b.by=c.R}if(e==">"){if(ab(b.F(1))){b.a5(2
+);c.R=b.by;return 9}b.a5(1);c.R=b.by;return 9}if(e=="-"||e=="_"||e=="*"){var o=0;while(!b.Y()){var k=b.H();if(b.H()==e){
+o++;b.a5(1);continue}if(ab(b.H())){b.a5(1);continue}break}if(b.Y()&&o>=3)return 14;b.by=c.R}if(this.bw.ExtraMode&&e=="*"
+&&b.F(1)=="["){b.a5(2);b.a8();b.az();while(!b.Y()&&b.H()!="]")b.a5(1);var n=ay(b.W());if(b.H()=="]"&&b.F(1)==":"&&n){b.
+a5(2);b.a8();b.az();b.bb();var v=b.W();this.bw.y(n,v);return 0}b.by=c.R}if((e=="*"||e=="+"||e=="-")&&ab(b.F(1))){b.a5(1)
+;b.a8();c.R=b.by;return 11}if(e==":"&&this.bw.ExtraMode&&ab(b.F(1))){b.a5(1);b.a8();c.R=b.by;return 25}if(X(e)){b.a5(1);
+while(X(b.H()))b.a5(1);if(b.aW(".")&&b.a8()){c.R=b.by;return 10}b.by=c.R}if(e=="["){if(this.bw.ExtraMode&&b.F(1)=="^"){
+var t=b.by;b.a5(2);var p=b.a4();if(p!=null&&b.aW("]")&&b.aW(":")){b.a8();c.R=b.by;c.X=p;return 28}b.by=t}var q=an(b,this
+.bw.ExtraMode);if(q!=null){this.bw.A(q);return 0}}return 12};a.ar=function(c){var b=c.attributes.markdown;if(b==
+undefined)if(this.bo)return 3;else return 0;delete c.attributes.markdown;if(b=="1")return(c.ap()&8)!=0?2:1;if(b=="block"
+)return 1;if(b=="deep")return 3;if(b=="span")return 2;return 4};a.aK=function(b,e,o,m){var g=b.by,k=1,j=false;while(!b.J
+()){if(!b.Z("<"))break;var n=b.by,h=ag(b);if(h==null){b.a5(1);continue}if(this.bw.SafeMode&&m==4&&!j)if(!h.at())j=true;
+if(h.closed)continue;if(h.name==o.name)if(h.closing){k--;if(k==0){b.a8();b.aZ();e.v=22;e.X=o;e.a3(b.by);switch(m){case 2
+:var c=this.T(g);c.E=b.E;c.v=17;c.R=g;c.N=n-g;e.C=[];e.C.push(c);break;case 1:case 3:var p=new D(this.bw,m==3);e.C=p.aL(
+b.E,g,n-g);break;case 4:if(j){e.v=16;e.a3(b.by)}else{var c=this.T(g);c.E=b.E;c.v=15;c.R=g;c.N=n-g;e.C=[];e.C.push(c)}
+break}return true}}else k++}return false};a.a0=function(b,c){var g=b.by,h=ag(b);if(h==null)return false;if(h.closing)
+return false;var m=false;if(this.bw.SafeMode&&!h.at()||!this.bw.AllowUserHtml)m=true;var q=h.ap();if((q&1)==0)
+return false;if((q&4)!=0||h.closed){b.a8();b.aZ();c.N=b.by-c.R;c.v=m?16:15;return true}if((q&2)!=0){b.a8();if(!b.Y())
+return false}var o=this.bw.ExtractHeadBlocks&&h.name.toLowerCase()=="head",t=b.by;if(!o&&this.bw.ExtraMode){var n=this.
+ar(h);if(n!=0)return this.aK(b,c,h,n)}var k=null,p=1;while(!b.J()){if(!b.Z("<"))break;var s=b.by,j=ag(b);if(j==null){b.
+a5(1);continue}if(this.bw.SafeMode&&!j.at())m=true;if(j.closed)continue;if(!o&&!j.closing&&this.bw.ExtraMode&&!m){var n=
+this.ar(j);if(n!=0){var r=this.T(g);if(this.aK(b,r,j,n)){if(k==null)k=[];if(s>g){var e=this.T(g);e.E=b.E;e.v=15;e.R=g;e.
+N=s-g;k.push(e)}k.push(r);g=b.by;continue}else this.ai(r)}}if(j.name==h.name&&!j.closed)if(j.closing){p--;if(p==0){b.a8(
+);b.aZ();if(m){c.v=16;c.a3(b.by);return true}if(k!=null){if(b.by>g){var e=this.T(g);e.E=b.E;e.v=15;e.R=g;e.N=b.by-g;k.
+push(e)}c.v=23;c.a3(b.by);c.C=k;return true}if(o){var v=b.E.substr(t,s-t);this.bw.HeadBlockContent=this.bw.
+HeadBlockContent+ay(v)+"\n";c.v=15;c.R=b.bK;c.contentEnd=b.bK;c.ay=b.bK;return true}c.v=15;c.N=b.by-c.R;return true}}
+else p++}return 0};a.M=function(b){var r=b[0].v,t=b[0].aq();for(var c=1;c<b.length;c++){if(b[c].v==12&&(b[c-1].v==12||b[
+c-1].v==11||b[c-1].v==10)){b[c-1].a3(b[c].ao());this.ai(b[c]);b.splice(c,1);c--;continue}if(b[c].v!=13&&b[c].v!=0){var s
+=b[c].aq();if(s>t){b[c].v=13;var v=b[c].ao();b[c].R=b[c].ay+s;b[c].a3(v)}}}var h=this.T(0);h.v=r==11?21:20;h.C=[];for(
+var c=0;c<b.length;c++){var k=c;while(k>0&&b[k-1].v==0)k--;var g=c;while(g<b.length-1&&b[g+1].v!=11&&b[g+1].v!=10)g++;
+if(k==g)h.C.push(this.T().V(b[c]));else{var o=false,n=this.bw.as();for(var e=k;e<=g;e++){var m=b[e];n.x(m.E.substr(m.R,m
+.N));n.x("\n");if(b[e].v==0)o=true}var j=this.T();j.v=19;j.ay=b[k].ay;var p=new D(this.bw);p.bx=r;j.C=p.aH(n.bh());if(!o
+)for(var e=0;e<j.C.length;e++){var q=j.C[e];if(q.v==12)q.v=17}h.C.push(j)}c=g}h.ay=h.C[0].ay;this.aj(b);b.length=0;
+return h};a.G=function(b){for(var c=1;c<b.length;c++)if(b[c].v==12&&(b[c-1].v==12||b[c-1].v==25)){b[c-1].a3(b[c].ao());
+this.ai(b[c]);b.splice(c,1);c--;continue}var k=b[0].X;if(b.length==1&&!k){var m=b[0];b.length=0;return m}var h=this.bw.
+as();for(var c=0;c<b.length;c++){var g=b[c];h.x(g.E.substr(g.R,g.N));h.x("\n")}var e=this.T(b[0].ay);e.v=25;var j=new D(
+this.bw);j.bx=25;e.C=j.aH(h.bh());this.aj(b);b.length=0;return e};a.I=function(e){var c=null;for(var b=0;b<e.length;b++)
+switch(e[b].v){case 26:case 25:if(c==null){c=this.T(e[b].ay);c.v=27;c.C=[];e.splice(b,0,c);b++}c.C.push(e[b]);e.splice(b
+,1);b--;break;default:c=null;break}};a.L=function(c){for(var b=1;b<c.length;b++)if(c[b].v==12&&(c[b-1].v==12||c[b-1].v==
+28)){c[b-1].a3(c[b].ao());this.ai(c[b]);c.splice(b,1);b--;continue}var h=this.bw.as();for(var b=0;b<c.length;b++){var g=
+c[b];h.x(g.E.substr(g.R,g.N));h.x("\n")}var j=new D(this.bw);j.bx=28;var e=this.T(c[0].ay);e.v=28;e.X=c[0].X;e.C=j.aH(h.
+bh());this.aj(c);c.length=0;return e};a.aJ=function(b,e){var m=b.by,k=b.H();b.az();while(b.H()==k)b.a5(1);var g=b.W();
+if(g.length<3)return false;b.a8();if(!b.Y())return false;b.aZ();var j=b.by;if(!b.Z(g))return false;if(!Y(b.F(-1)))
+return false;var h=b.by;b.a5(g.length);b.a8();if(!b.Y())return false;e.v=18;e.C=[];h--;var c=this.T(m);c.v=13;c.E=b.E;c.
+R=j;c.N=h-j;e.C.push(c);return true};function H(){this.bp=[];this.bu=null;this.bA=[]}a=H.prototype;a.ax=false;a.bk=false
+;a.aG=function(b){b.a8();if(b.Y())return null;var e=this.ax;if(this.ax&&!b.aW("|")){e=true;return null}var c=[];while(!b
+.Y()){b.az();while(!b.Y()&&b.H()!="|")b.a2(true);c.push(ay(b.W()));e|=b.aW("|")}if(!e)return null;while(c.length<this.bp
+.length)c.push("&nbsp;");b.aZ();return c};a.aT=function(h,b,e,g){for(var c=0;c<e.length;c++){b.x("\t<");b.x(g);if(c<this
+.bp.length)switch(this.bp[c]){case 1:b.x(' align="left"');break;case 2:b.x(' align="right"');break;case 3:b.x(
+' align="center"');break}b.x(">");h.bz.af(b,e[c]);b.x("</");b.x(g);b.x(">\n")}};a.l=function(e,b){b.x("<table>\n");if(
+this.bu!=null){b.x("<thead>\n<tr>\n");this.aT(e,b,this.bu,"th");b.x("</tr>\n</thead>\n")}b.x("<tbody>\n");for(var c=0;c<
+this.bA.length;c++){var g=this.bA[c];b.x("<tr>\n");this.aT(e,b,g,"td");b.x("</tr>\n")}b.x("</tbody>\n");b.x("</table>\n"
+)};function av(b){b.a8();if(b.H()!="|"&&b.H()!=":"&&b.H()!="-")return null;var c=null;if(b.aW("|")){c=new H();c.ax=true}
+while(true){b.a8();if(b.H()=="|")return null;var g=b.aW(":");while(b.H()=="-")b.a5(1);var h=b.aW(":");b.a8();var e=0;if(
+g&&h)e=3;else if(g)e=1;else if(h)e=2;if(b.Y()){if(c==null)return null;c.bp.push(e);return c}if(!b.aW("|"))return null;
+if(c==null)c=new H();c.bp.push(e);b.a8();if(b.Y()){c.bk=true;return c}}}this.Markdown=i;this.HtmlTag=w})();if(typeof 
+exports!=="undefined")exports.Markdown=MarkdownDeep.Markdown;
 // MarkdownDeep - http://www.toptensoftware.com/markdowndeep
 // Copyright (C) 2010-2011 Topten Software
 var MarkdownDeepEditor=new(function(){var q=false,w={Z:"undo",Y:"redo",B:"bold",I:"italic",H:"heading",K:"code",U:


### PR DESCRIPTION
I added a property AllowUserHtml with the default value "true" so that the current behavior doesn't change until you explicitly set the property to false.
When the property is set to false, every HTML from the users will be escaped and they can only use the markdown syntax for formatting.
When someone writes
\<b>test\</b>
the result is not
<b>test</b>
instead it is
\<b>test\</b>.

I need this for a website where the users should be able to use the simple formatting of Markdown but I know that they won't use HTML intentionally and it would confuse them if they coincidentally type an HTML tag and it would not be shown as-is on the website. So I use Markdown as kind of a better BBCode ;)